### PR TITLE
[TaxonomyPicker] Add configurable errorMessage to control

### DIFF
--- a/change/@dlw-digitalworkplace-dw-react-controls-b10f797a-0b04-4053-923f-7e04993decdf.json
+++ b/change/@dlw-digitalworkplace-dw-react-controls-b10f797a-0b04-4053-923f-7e04993decdf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add configurable errorMessage to control",
+  "packageName": "@dlw-digitalworkplace/dw-react-controls",
+  "email": "nick.sevens@delaware.pro",
+  "dependentChangeType": "none"
+}

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
@@ -43,6 +43,8 @@ export interface ITaxonomyPickerProps {
 
 	theme?: ITheme;
 
+	errorMessage?: string | JSX.Element;
+
 	onChange(items: ITermValue[]): void;
 
 	/**
@@ -60,6 +62,8 @@ export interface ITaxonomyPickerProps {
 	 * @param message The current message that is being returned.
 	 */
 	onReceiveTermCreationSuccessMessage?(newValue: string, message: string): string | JSX.Element;
+
+	onGetErrorMessage?(selectedItems: ITermValue[]): string | JSX.Element | PromiseLike<string | JSX.Element> | undefined;
 }
 
 export interface ITaxonomyPickerStyleProps {

--- a/packages/dw-react-controls/src/components/TermPicker/TermPicker.tsx
+++ b/packages/dw-react-controls/src/components/TermPicker/TermPicker.tsx
@@ -7,6 +7,7 @@ import { getStyles } from "./TermPicker.styles";
 import { ITermPickerProps } from "./TermPicker.types";
 
 export const TermPicker = ({
+	isInvalid: isInvalidProp,
 	onBlur: onBlurProp,
 	onEmptyInputFocus: onInputFocusProp,
 	onFocus: onFocusProp,
@@ -39,7 +40,13 @@ export const TermPicker = ({
 		setIsFocused(false);
 	};
 
-	const styles = getStyles({ ...props, isFocused, isInvalid, theme, styles: customStyles });
+	const styles = getStyles({
+		...props,
+		isFocused,
+		isInvalid: isInvalidProp === undefined ? isInvalid : isInvalidProp,
+		theme,
+		styles: customStyles
+	});
 
 	return <TermPickerBase {...props} onEmptyInputFocus={onInputFocus} onBlur={onBlur} styles={styles} />;
 };

--- a/packages/dw-react-controls/src/components/TermPicker/TermPicker.types.ts
+++ b/packages/dw-react-controls/src/components/TermPicker/TermPicker.types.ts
@@ -9,17 +9,22 @@ import { ITermValue } from "./models";
 
 export interface ITermPickerProps extends IBasePickerProps<ITermValue> {
 	/**
-	 * Optional class for the root TaxonomyPicker element
+	 * Specifies if the picker is in an invalid state.
+	 */
+	isInvalid?: boolean;
+
+	/**
+	 * Optional class for the root TaxonomyPicker element.
 	 */
 	className?: string;
 
 	/**
-	 * Call to apply custom styling on the TaxonomyPicker element
+	 * Call to apply custom styling on the TaxonomyPicker element.
 	 */
 	styles?: IStyleFunctionOrObject<ITermPickerStyleProps, ITermPickerStyles>;
 
 	/**
-	 * The current theme applied to the control
+	 * The current theme applied to the control.
 	 */
 	theme?: ITheme;
 }


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [x] Component improvement
- [ ] New component
- [ ] New package
- [ ] Other

## Description

Add configurable errorMessage and onGetErrorMessage to control. Similar to TextField implementation.
