### PR TITLE
[SharePointTaxonomyProvider] Ignore already selected items

### DIFF
--- a/change/@dlw-digitalworkplace-taxonomyprovider-sharepoint-5bc65ae7-4208-4e5e-a5a4-262de7ff7c57.json
+++ b/change/@dlw-digitalworkplace-taxonomyprovider-sharepoint-5bc65ae7-4208-4e5e-a5a4-262de7ff7c57.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "SharePointTaxonomyProvider: Don't return already selected items when retrieving data",
+  "packageName": "@dlw-digitalworkplace/taxonomyprovider-sharepoint",
+  "email": "nick.sevens@delaware.pro",
+  "dependentChangeType": "patch"
+}

--- a/packages/taxonomyProviders/sharepoint/src/SharePointTaxonomyProvider.ts
+++ b/packages/taxonomyProviders/sharepoint/src/SharePointTaxonomyProvider.ts
@@ -96,6 +96,11 @@ export class SharePointTaxonomyProvider implements ITaxonomyProvider {
 		for (let i = 0; i < this.cachedTerms!.length && result.length < options.maxItems!; i++) {
 			const term = this.cachedTerms![i];
 
+			// skip item if in ignore list
+			if (options.keysToIgnore && options.keysToIgnore.indexOf(term.get_id().toString()) !== -1) {
+				continue;
+			}
+
 			// skip deprecated term if requested
 			if (options.trimDeprecated && term.get_isDeprecated()) {
 				continue;


### PR DESCRIPTION
## Type of change

- [x] Bugfix
- [ ] Component improvement
- [ ] New component
- [ ] New package
- [ ] Other

## Description

Fix an issue where already selected items are not removed from the provider's result set.
