### PR TITLE
[TaxonomyPicker] Allow overriding 'open dialog' button rendering

### DIFF
--- a/change/@dlw-digitalworkplace-dw-react-controls-0aed6c5f-f68f-45df-8853-4bba954d58fd.json
+++ b/change/@dlw-digitalworkplace-dw-react-controls-0aed6c5f-f68f-45df-8853-4bba954d58fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "TaxonomyPicker: allow overriding default openDialog button",
+  "packageName": "@dlw-digitalworkplace/dw-react-controls",
+  "email": "nick.sevens@delaware.pro",
+  "dependentChangeType": "none"
+}

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.base.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.base.tsx
@@ -2,11 +2,17 @@ import { useStateIfMounted } from "@dlw-digitalworkplace/dw-react-utils";
 import { IconButton } from "office-ui-fabric-react/lib/Button";
 import { ValidationState } from "office-ui-fabric-react/lib/components/pickers/BasePicker.types";
 import { Label } from "office-ui-fabric-react/lib/Label";
-import { classNamesFunction } from "office-ui-fabric-react/lib/Utilities";
+import { classNamesFunction, IRenderFunction } from "office-ui-fabric-react/lib/Utilities";
 import * as React from "react";
+import { composeRenderFunction } from "../../utilities";
 import { ITermValue, TermPicker } from "../TermPicker";
 import { ITerm, ITermCreationResult, ITermFilterOptions } from "./models";
-import { ITaxonomyPickerProps, ITaxonomyPickerStyleProps, ITaxonomyPickerStyles } from "./TaxonomyPicker.types";
+import {
+	ITaxonomyPickerDialogButtonProps,
+	ITaxonomyPickerProps,
+	ITaxonomyPickerStyleProps,
+	ITaxonomyPickerStyles
+} from "./TaxonomyPicker.types";
 import { TaxonomyPickerDialog } from "./TaxonomyPickerDialog";
 
 const getClassNames = classNamesFunction<ITaxonomyPickerStyleProps, ITaxonomyPickerStyles>();
@@ -29,6 +35,7 @@ export const TaxonomyPickerBase: React.FC<ITaxonomyPickerProps> = ({
 	onGetErrorMessage,
 	onReceiveTermCreationFailedMessage,
 	onReceiveTermCreationSuccessMessage,
+	onRenderOpenDialogButton,
 	required,
 	styles,
 	theme
@@ -280,6 +287,24 @@ export const TaxonomyPickerBase: React.FC<ITaxonomyPickerProps> = ({
 
 	const errorMessage = React.useMemo(() => _errorMessage || errorMessageProp, [_errorMessage, errorMessageProp]);
 
+	const renderOpenDialogButton: IRenderFunction<ITaxonomyPickerDialogButtonProps> = (
+		props?: ITaxonomyPickerDialogButtonProps
+	) => {
+		return props ? (
+			<IconButton
+				disabled={props.disabled}
+				iconProps={{
+					iconName: "TagUnknown12"
+				}}
+				onClick={props.onButtonClick}
+			/>
+		) : null;
+	};
+
+	const finalOnRenderOpenDialogButton = onRenderOpenDialogButton
+		? composeRenderFunction(onRenderOpenDialogButton, renderOpenDialogButton)
+		: renderOpenDialogButton;
+
 	return (
 		<div className={classNames.root}>
 			{label && (
@@ -300,13 +325,10 @@ export const TaxonomyPickerBase: React.FC<ITaxonomyPickerProps> = ({
 					onValidateInput={onValidateInput}
 					selectedItems={selectedItems}
 				/>
-				<IconButton
-					disabled={disabled}
-					iconProps={{
-						iconName: "TagUnknown12"
-					}}
-					onClick={handlePopupButtonClick}
-				/>
+				{finalOnRenderOpenDialogButton({
+					disabled: !!disabled,
+					onButtonClick: handlePopupButtonClick
+				})}
 			</div>
 
 			{errorMessage && renderMessage(errorMessage, false)}

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
@@ -1,6 +1,6 @@
 import { ILabelProps } from "office-ui-fabric-react/lib/Label";
 import { IStyle, ITheme } from "office-ui-fabric-react/lib/Styling";
-import { IStyleFunctionOrObject } from "office-ui-fabric-react/lib/Utilities";
+import { IRenderFunction, IStyleFunctionOrObject } from "office-ui-fabric-react/lib/Utilities";
 import { ITermValue } from "../TermPicker";
 import { ITaxonomyProvider } from "./models";
 import { ITaxonomyPickerDialogProps } from "./TaxonomyPickerDialog.types";
@@ -45,6 +45,8 @@ export interface ITaxonomyPickerProps {
 
 	errorMessage?: string | JSX.Element;
 
+	onRenderOpenDialogButton?: IRenderFunction<ITaxonomyPickerDialogButtonProps>;
+
 	onChange(items: ITermValue[]): void;
 
 	/**
@@ -77,4 +79,9 @@ export interface ITaxonomyPickerStyles {
 	input?: IStyle;
 	errorMessage?: IStyle;
 	successMessage?: IStyle;
+}
+
+export interface ITaxonomyPickerDialogButtonProps {
+	disabled: boolean;
+	onButtonClick: React.MouseEventHandler<HTMLAnchorElement | HTMLButtonElement | HTMLDivElement>;
 }

--- a/packages/dw-react-controls/src/components/TreeItem/TreeItem.base.tsx
+++ b/packages/dw-react-controls/src/components/TreeItem/TreeItem.base.tsx
@@ -8,6 +8,7 @@ import { ContextualMenu, IContextualMenuItem } from "office-ui-fabric-react/lib/
 import { Icon } from "office-ui-fabric-react/lib/Icon";
 import { classNamesFunction, IRenderFunction } from "office-ui-fabric-react/lib/Utilities";
 import * as React from "react";
+import { composeRenderFunction } from "../../utilities";
 import TreeViewContext from "../TreeView/TreeView.context";
 import { TreeItemContent } from "./sections/TreeItemContent";
 import { ITreeItemContentProps } from "./sections/TreeItemContent.types";
@@ -83,17 +84,10 @@ export const TreeItemBase: React.FC<ITreeItemProps> = React.forwardRef<HTMLLIEle
 
 	const classNames = getClassNames(styles, { className, disabled, expanded, selected, theme: theme! });
 
-	const renderItemContents: IRenderFunction<ITreeItemContentProps> = (props: ITreeItemContentProps | undefined) => {
-		return props ? <TreeItemContent {...props} /> : null;
-	};
-
-	const composeRenderFunction = (
-		outer: IRenderFunction<ITreeItemContentProps>,
-		inner: IRenderFunction<ITreeItemContentProps>
-	): IRenderFunction<ITreeItemContentProps> => {
-		return (outerProps?: ITreeItemContentProps, defaultRender?: IRenderFunction<ITreeItemContentProps>) => {
-			return outer(outerProps, defaultRender ? defaultRender : inner);
-		};
+	const renderItemContents: IRenderFunction<ITreeItemContentProps> = (
+		contentProps: ITreeItemContentProps | undefined
+	) => {
+		return contentProps ? <TreeItemContent {...contentProps} /> : null;
 	};
 
 	const finalOnRenderItemContents = onRenderItemContents

--- a/packages/dw-react-controls/src/components/TreeItem/TreeItem.types.ts
+++ b/packages/dw-react-controls/src/components/TreeItem/TreeItem.types.ts
@@ -44,6 +44,11 @@ export interface ITreeItemProps {
 	theme?: ITheme;
 
 	/**
+	 * When specified it will override the default rendering of the TreeItemContent section
+	 */
+	onRenderItemContents?: IRenderFunction<ITreeItemContentProps>;
+
+	/**
 	 * Optional callback when the tree node has been clicked
 	 */
 	onClick?(event: React.MouseEvent<HTMLElement>): void;
@@ -52,11 +57,6 @@ export interface ITreeItemProps {
 	 * Optional callback when the tree node has been invoked
 	 */
 	onInvoke?(event: React.MouseEvent<HTMLElement>): void;
-
-	/**
-	 * When specified it will override the default rendering of the TreeItemContent section
-	 */
-	onRenderItemContents?: IRenderFunction<ITreeItemContentProps>;
 }
 
 export interface ITreeItemStyleProps {

--- a/packages/dw-react-controls/src/utilities/composeRenderFunction.ts
+++ b/packages/dw-react-controls/src/utilities/composeRenderFunction.ts
@@ -1,0 +1,7 @@
+import { IRenderFunction } from "office-ui-fabric-react";
+
+export function composeRenderFunction<T>(outer: IRenderFunction<T>, inner: IRenderFunction<T>): IRenderFunction<T> {
+	return (outerProps?: T, defaultRender?: IRenderFunction<T>) => {
+		return outer(outerProps, defaultRender ? defaultRender : inner);
+	};
+}

--- a/packages/dw-react-controls/src/utilities/index.ts
+++ b/packages/dw-react-controls/src/utilities/index.ts
@@ -1,1 +1,2 @@
+export * from "./composeRenderFunction";
 export * from "./useTheme";


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [x] Component improvement
- [ ] New component
- [ ] New package
- [ ] Other

## Description

Allow custom rendering for the 'open dialog' button
