### PR TITLE
[WebPartTitle] Add option to render "more info" link in title

### DIFF
--- a/apps/demo-spfx-app/src/webparts/demoSPFxComponents/DemoSPFxComponentsWebPart.manifest.json
+++ b/apps/demo-spfx-app/src/webparts/demoSPFxComponents/DemoSPFxComponentsWebPart.manifest.json
@@ -23,7 +23,7 @@
 			"description": { "default": "Demo webpart showing the SPFx components." },
 			"officeFabricIconFontName": "Page",
 			"properties": {
-				"description": "DemoTaxonomyPicker"
+				"showMoreInfoLink": true
 			}
 		}
 	]

--- a/apps/demo-spfx-app/src/webparts/demoSPFxComponents/DemoSPFxComponentsWebPart.tsx
+++ b/apps/demo-spfx-app/src/webparts/demoSPFxComponents/DemoSPFxComponentsWebPart.tsx
@@ -34,6 +34,7 @@ export default class DemoSPFxComponentsWebPart extends BaseClientSideWebPart<IDe
 				hidden={this.properties.hideTitle}
 				title={this.properties.title}
 				theme={createTheme(this._themeVariant)}
+				onRenderMoreInfoLink={this.properties.showMoreInfoLink && (() => <a href={""}>All items</a>)}
 				onUpdate={this._updateWebPartTitle}
 			/>,
 			this.domElement
@@ -62,6 +63,9 @@ export default class DemoSPFxComponentsWebPart extends BaseClientSideWebPart<IDe
 							groupFields: [
 								PropertyPaneToggle("hideTitle", {
 									label: strings.HideTitlePropertyLabel
+								}),
+								PropertyPaneToggle("showMoreInfoLink", {
+									label: strings.ShowMoreInfoLinkPropertyLabel
 								})
 							]
 						}

--- a/apps/demo-spfx-app/src/webparts/demoSPFxComponents/DemoSPFxComponentsWebPart.types.ts
+++ b/apps/demo-spfx-app/src/webparts/demoSPFxComponents/DemoSPFxComponentsWebPart.types.ts
@@ -1,4 +1,5 @@
 export interface IDemoSPFxComponentsWebPartProps {
 	hideTitle?: boolean;
+	showMoreInfoLink?: boolean;
 	title: string;
 }

--- a/apps/demo-spfx-app/src/webparts/demoSPFxComponents/loc/en-us.js
+++ b/apps/demo-spfx-app/src/webparts/demoSPFxComponents/loc/en-us.js
@@ -1,6 +1,7 @@
 define([], function () {
 	return {
 		BasicGroupName: "General settings",
-		HideTitlePropertyLabel: "Hide webpart title"
+		HideTitlePropertyLabel: "Hide webpart title",
+		ShowMoreInfoLinkPropertyLabel: "Show more info link"
 	};
 });

--- a/apps/demo-spfx-app/src/webparts/demoSPFxComponents/loc/mystrings.d.ts
+++ b/apps/demo-spfx-app/src/webparts/demoSPFxComponents/loc/mystrings.d.ts
@@ -1,6 +1,7 @@
 declare interface IDemoSPFxComponentsWebPartStrings {
 	BasicGroupName: string;
 	HideTitlePropertyLabel: string;
+	ShowMoreInfoLinkPropertyLabel: string;
 }
 
 declare module "DemoSPFxComponentsWebPartStrings" {

--- a/change/@dlw-digitalworkplace-dw-spfx-controls-0bf6e1b0-0894-4d26-bfd0-b8023266a1f4.json
+++ b/change/@dlw-digitalworkplace-dw-spfx-controls-0bf6e1b0-0894-4d26-bfd0-b8023266a1f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add more info link to webpart title",
+  "packageName": "@dlw-digitalworkplace/dw-spfx-controls",
+  "email": "nick.sevens@delaware.pro",
+  "dependentChangeType": "none"
+}

--- a/packages/dw-spfx-controls/src/components/WebPartTitle/WebPartTitle.base.tsx
+++ b/packages/dw-spfx-controls/src/components/WebPartTitle/WebPartTitle.base.tsx
@@ -8,7 +8,7 @@ import { IWebPartTitleProps, IWebPartTitleStyleProps, IWebPartTitleStyles } from
 const getClassNames = classNamesFunction<IWebPartTitleStyleProps, IWebPartTitleStyles>();
 
 export const WebPartTitleBase: React.FC<IWebPartTitleProps> = (props) => {
-	const { className, displayMode, hidden, onUpdate, placeholder, styles, theme, title } = props;
+	const { className, displayMode, hidden, onRenderMoreInfoLink, onUpdate, placeholder, styles, theme, title } = props;
 
 	const classNames = getClassNames(styles, { className, theme: theme });
 
@@ -19,36 +19,36 @@ export const WebPartTitleBase: React.FC<IWebPartTitleProps> = (props) => {
 		onUpdate(ev.target.value);
 	};
 
-	if (displayMode === DisplayMode.Edit) {
-		// if in edit mode
-		return (
-			<div className={classNames.root}>
-				<TextareaAutosize
-					aria-label={strings.WebPartTitleLabel}
-					className={classNames.textarea}
-					data-testid="input"
-					defaultValue={title}
-					placeholder={placeholder || strings.WebPartTitlePlaceholder}
-					onChange={handleChange}
-				/>
-			</div>
-		);
+	const isHidden = displayMode === DisplayMode.Read && (hidden || (!title && !onRenderMoreInfoLink));
+
+	if (isHidden) {
+		return null;
 	}
 
-	if (displayMode === DisplayMode.Read) {
-		// if in display mode
-		if (!title || hidden) {
-			return null;
-		}
+	return (
+		<div className={classNames.root}>
+			{(displayMode === DisplayMode.Edit || !!title) && (
+				<div className={classNames.title}>
+					{displayMode === DisplayMode.Edit ? (
+						<TextareaAutosize
+							aria-label={strings.WebPartTitleLabel}
+							className={classNames.textarea}
+							data-testid="input"
+							defaultValue={title}
+							placeholder={placeholder || strings.WebPartTitlePlaceholder}
+							onChange={handleChange}
+						/>
+					) : (
+						!!title && (
+							<span role="heading" aria-level={2} data-testid="title">
+								{title}
+							</span>
+						)
+					)}
+				</div>
+			)}
 
-		return (
-			<div className={classNames.root}>
-				<span role="heading" aria-level={2} data-testid="title">
-					{title}
-				</span>
-			</div>
-		);
-	}
-
-	return null;
+			{!!onRenderMoreInfoLink && <div className={classNames.moreInfoLink}>{onRenderMoreInfoLink()}</div>}
+		</div>
+	);
 };

--- a/packages/dw-spfx-controls/src/components/WebPartTitle/WebPartTitle.styles.ts
+++ b/packages/dw-spfx-controls/src/components/WebPartTitle/WebPartTitle.styles.ts
@@ -1,7 +1,9 @@
 import { IWebPartTitleStyleProps, IWebPartTitleStyles } from "./WebPartTitle.types";
 
 const GlobalClassNames = {
-	root: "dw-WebPartTitle"
+	root: "dw-WebPartTitle",
+	title: "dw-WebPartTitle-Title",
+	moreInfoLink: "dw-WebPartTitle-More"
 };
 
 export const getStyles = (props: IWebPartTitleStyleProps): IWebPartTitleStyles => {
@@ -12,18 +14,25 @@ export const getStyles = (props: IWebPartTitleStyleProps): IWebPartTitleStyles =
 		root: [
 			classNames.root,
 			{
-				...theme.fonts.xLarge,
+				alignItems: "baseline",
+				display: "flex",
+				flexDirection: "row",
+				justifyContent: "flex-end",
 				marginBottom: "18px",
 				marginLeft: theme.rtl && theme.spacing.l2,
 				marginRight: !theme.rtl && theme.spacing.l2,
 				marginTop: 0,
-				whiteSpace: "pre-wrap",
-
-				textarea: {
-					color: theme.semanticColors.bodyText
-				}
+				whiteSpace: "pre-wrap"
 			},
 			className
+		],
+
+		title: [
+			classNames.title,
+			{
+				...theme.fonts.xLarge,
+				flexGrow: 1
+			}
 		],
 
 		textarea: [
@@ -31,6 +40,7 @@ export const getStyles = (props: IWebPartTitleStyleProps): IWebPartTitleStyles =
 				backgroundColor: "transparent",
 				border: "none",
 				boxSizing: "border-box",
+				color: theme.semanticColors.bodyText,
 				display: "block",
 				margin: 0,
 				outline: 0,
@@ -45,6 +55,14 @@ export const getStyles = (props: IWebPartTitleStyleProps): IWebPartTitleStyles =
 				"&::placeholder": {
 					color: theme.semanticColors.bodySubtext
 				}
+			}
+		],
+
+		moreInfoLink: [
+			classNames.moreInfoLink,
+			{
+				fontSize: theme.fonts.medium.fontSize,
+				whiteSpace: "nowrap"
 			}
 		]
 	};

--- a/packages/dw-spfx-controls/src/components/WebPartTitle/WebPartTitle.types.ts
+++ b/packages/dw-spfx-controls/src/components/WebPartTitle/WebPartTitle.types.ts
@@ -9,16 +9,18 @@ export interface IWebPartTitleProps {
 	title: string;
 
 	/**
-	 * Optional class for the root TreeView element
+	 * Optional class for the root WebPartTitle element
 	 */
 	className?: string;
 
 	/**
-	 * Call to apply custom styling on the TreeView element
+	 * Call to apply custom styling on the WebPartTitle element
 	 */
 	styles?: IStyleFunctionOrObject<IWebPartTitleStyleProps, IWebPartTitleStyles>;
 
 	theme?: ITheme;
+
+	onRenderMoreInfoLink?(): JSX.Element;
 
 	onUpdate(value: string): void;
 }
@@ -31,5 +33,7 @@ export interface IWebPartTitleStyleProps {
 
 export interface IWebPartTitleStyles {
 	root?: IStyle;
+	title?: IStyle;
 	textarea?: IStyle;
+	moreInfoLink?: IStyle;
 }


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [x] Component improvement
- [ ] New component
- [ ] New package
- [ ] Other

## Description

Adds an option to render a "more info" link in the webpart title.

`onRenderMoreInfoLink={() => <a href="...">All items</a>)}`