### PR TITLE
Features: useWindowEvent and useDrag hook

### DIFF
--- a/change/@dlw-digitalworkplace-dw-react-utils-1137c25e-443d-44f5-99df-bb0a365a60aa.json
+++ b/change/@dlw-digitalworkplace-dw-react-utils-1137c25e-443d-44f5-99df-bb0a365a60aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add useWindowEvent and useDrag hook",
+  "packageName": "@dlw-digitalworkplace/dw-react-utils",
+  "email": "robin.agten@delaware.pro",
+  "dependentChangeType": "patch"
+}

--- a/packages/dw-react-utils/src/hooks/index.ts
+++ b/packages/dw-react-utils/src/hooks/index.ts
@@ -1,3 +1,5 @@
 export * from "./useControlled";
 export * from "./useIsMounted";
 export * from "./useStateIfMounted";
+export * from "./useWindowEvent";
+export * from "./useDrag";

--- a/packages/dw-react-utils/src/hooks/useDrag.ts
+++ b/packages/dw-react-utils/src/hooks/useDrag.ts
@@ -49,7 +49,7 @@ export const useDrag = (
   useWindowEvent("mouseup", () => {
     if (isDragging) {
       setIsDragging(false);
-			onDragEnd && onDragEnd(positionX, positionY);
+      onDragEnd && onDragEnd(positionX, positionY);
     }
   });
 

--- a/packages/dw-react-utils/src/hooks/useDrag.ts
+++ b/packages/dw-react-utils/src/hooks/useDrag.ts
@@ -10,9 +10,9 @@ import { useWindowEvent } from "..";
  * @param element The HTML element you want to target
  * @param direction The direction of the drag. Default is both directions
  * @param onDragEnd Callback that is fired when the drag movement stops
- * @returns isDragging: Boolean indicating if the dragging is ongoing
- * @returns positionX: The current X position of the drag
- * @returns positionY: The current Y position of the drag
+ * @returns isDragging - Boolean indicating if the dragging is ongoing
+ * @returns positionX - The current X position of the drag
+ * @returns positionY - The current Y position of the drag
  */
 export const useDrag = (
   element: HTMLElement | undefined,

--- a/packages/dw-react-utils/src/hooks/useDrag.ts
+++ b/packages/dw-react-utils/src/hooks/useDrag.ts
@@ -17,11 +17,11 @@ import { useWindowEvent } from "..";
 export const useDrag = (
   element: HTMLElement | undefined,
   direction?: "vertical" | "horizontal",
-	onDragEnd?:(positionX: number, positionY: number) => void
+  onDragEnd?:(positionX: number, positionY: number) => void
 ): {
-	isDragging: boolean,
-	positionX: number,
-	positionY: number
+  isDragging: boolean,
+  positionX: number,
+  positionY: number
 } => {
   const startXPosition = React.useRef<number>(0);
   const startYPosition = React.useRef<number>(0);

--- a/packages/dw-react-utils/src/hooks/useDrag.ts
+++ b/packages/dw-react-utils/src/hooks/useDrag.ts
@@ -1,0 +1,78 @@
+import * as React from "react";
+import { useWindowEvent } from "..";
+
+/**
+ * @public
+ *
+ * The useDrag hook can be used to make HTML elements draggable.
+ * Important: The target must be in a non static position (e.g. relative)
+ *
+ * @param element The HTML element you want to target
+ * @param direction The direction of the drag. Default is both directions
+ * @param onDragEnd Callback that is fired when the drag movement stops
+ * @returns isDragging: Boolean indicating if the dragging is ongoing
+ * @returns positionX: The current X position of the drag
+ * @returns positionY: The current Y position of the drag
+ */
+export const useDrag = (
+  element: HTMLElement | undefined,
+  direction?: "vertical" | "horizontal",
+	onDragEnd?:(positionX: number, positionY: number) => void
+): {
+	isDragging: boolean,
+	positionX: number,
+	positionY: number
+} => {
+  const startXPosition = React.useRef<number>(0);
+  const startYPosition = React.useRef<number>(0);
+
+  const [positionX, setPositionX] = React.useState<number>(0);
+  const [positionY, setPositionY] = React.useState<number>(0);
+  const [isDragging, setIsDragging] = React.useState<boolean>(false);
+
+  useWindowEvent("mousemove", (event: Event) => {
+    const e = event as MouseEvent;
+    if (isDragging) {
+      if (direction !== "horizontal") {
+        const y = e.pageY - startYPosition.current;
+        setPositionY(y);
+        if (element) { element.style.top = `${y}px`; }
+      }
+      if (direction !== "vertical") {
+        const x = e.pageX - startXPosition.current;
+        setPositionX(x);
+        if (element) { element.style.left = `${x}px`; }
+      }
+    }
+  });
+
+  useWindowEvent("mouseup", () => {
+    if (isDragging) {
+      setIsDragging(false);
+			onDragEnd && onDragEnd(positionX, positionY);
+    }
+  });
+
+  React.useEffect(() => {
+    if (!!element) {
+      element.addEventListener("mousedown", (e: MouseEvent) => {
+        if (e.currentTarget instanceof HTMLElement) {
+          setIsDragging(true);
+          const left = element.style.left ? parseInt(element.style.left, 0) : 0;
+          const top = element.style.top ? parseInt(element.style.top, 0) : 0;
+          startXPosition.current = e.pageX - left;
+          startYPosition.current = e.pageY - top;
+        }
+        else {
+          throw new Error("Your target must be an html element");
+        }
+      });
+    }
+  }, [element]);
+
+  return {
+    isDragging,
+    positionX,
+    positionY
+  };
+};

--- a/packages/dw-react-utils/src/hooks/useWindowEvent.ts
+++ b/packages/dw-react-utils/src/hooks/useWindowEvent.ts
@@ -9,7 +9,6 @@ import * as React from "react";
  * @param type The type of window event
  * @param callback The callback function to execute when the event is triggered
  */
-
 export const useWindowEvent = (type: keyof WindowEventMap, callback: (ev: Event) => void): void => {
   React.useEffect(() => {
     window.addEventListener(type, callback);

--- a/packages/dw-react-utils/src/hooks/useWindowEvent.ts
+++ b/packages/dw-react-utils/src/hooks/useWindowEvent.ts
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+/**
+ * @public
+ *
+ * Helper hook to register events on the window.
+ * The event will be correctly registered and unregistered as well.
+ *
+ * @param type The type of window event
+ * @param callback The callback function to execute when the event is triggered
+ */
+
+export const useWindowEvent = (type: keyof WindowEventMap, callback: (ev: Event) => void): void => {
+  React.useEffect(() => {
+    window.addEventListener(type, callback);
+    return () => window.removeEventListener(type, callback);
+  }, [type, callback]);
+};

--- a/packages/dw-react-utils/src/stories/hooks/useDrag.stories.mdx
+++ b/packages/dw-react-utils/src/stories/hooks/useDrag.stories.mdx
@@ -2,7 +2,7 @@ import { ArgsTable, Meta, Story, Canvas } from "@storybook/addon-docs";
 import * as stories from "./useDrag.stories";
 import { useDrag } from "../../hooks"
 
-<Meta title="Utils/hooks/useDrag" component={useDrag	}/>
+<Meta title="Utils/hooks/useDrag" component={ useDrag	}/>
 
 # useDrag
 
@@ -13,7 +13,7 @@ The hook has the following input:
 
 The hook provides the following output:
  - isDragging: boolean to indicate is the element is being dragged or not
- - positionX / positionY: a number providing the moved possition of the element
+ - positionX / positionY: a number providing the moved position of the element
 
 > **Important:** The target must be in a non static position (e.g. relative)
 

--- a/packages/dw-react-utils/src/stories/hooks/useDrag.stories.mdx
+++ b/packages/dw-react-utils/src/stories/hooks/useDrag.stories.mdx
@@ -1,0 +1,48 @@
+import { ArgsTable, Meta, Story, Canvas } from "@storybook/addon-docs";
+import * as stories from "./useDrag.stories";
+import { useDrag } from "../../hooks"
+
+<Meta title="Utils/hooks/useDrag" component={useDrag	}/>
+
+# useDrag
+
+The `useDrag` hook is a very light weight hook that allows you to make an element draggable.
+The hook has the following input:
+ - element: the element that needs to be draggable
+ - direction: optional string that contains 'horizontal' or 'vertical'. If empty both directions are possible.
+
+The hook provides the following output:
+ - isDragging: boolean to indicate is the element is being dragged or not
+ - positionX / positionY: a number providing the moved possition of the element
+
+> **Important:** The target must be in a non static position (e.g. relative)
+
+## Usage
+
+```tsx
+const dragRef = React.useRef() as React.MutableRefObject<HTMLDivElement>;
+const [dragElement, setDragElement] = React.useState<HTMLElement>();
+const { isDragging, positionX, positionY } = useDrag(dragElement);
+```
+
+## All directions
+Below an example of the most basic usage.
+<Canvas withToolbar={true}>
+	<Story story={stories.Basic} name="Basic usage" />
+</Canvas>
+
+## Horizontal
+Enforce the drag movement in only one direction (e.g. horizontal).
+<Canvas withToolbar={true}>
+	<Story story={stories.Horizontal} name="Horizontal only" />
+</Canvas>
+
+## End Drag Callback
+Fire a callback when the drag has ended.
+<Canvas withToolbar={true}>
+	<Story story={stories.EndCallback} name="OnDragEnd Event" />
+</Canvas>
+
+## Properties
+<ArgsTable components={{ useDrag }} />
+

--- a/packages/dw-react-utils/src/stories/hooks/useDrag.stories.tsx
+++ b/packages/dw-react-utils/src/stories/hooks/useDrag.stories.tsx
@@ -20,12 +20,12 @@ const dragItemStyles: React.CSSProperties = {
 
 export const Basic: Story = () => {
 	const dragRef = React.useRef() as React.MutableRefObject<HTMLDivElement>;
-  const [dragElement, setDragElement] = React.useState<HTMLElement>();
+	const [dragElement, setDragElement] = React.useState<HTMLElement>();
 	const { isDragging, positionX, positionY } = useDrag(dragElement);
 
 	React.useEffect(() => {
-    setDragElement(dragRef.current);
-  }, []);
+		setDragElement(dragRef.current);
+	}, []);
 
 	return (
 		<div>
@@ -42,12 +42,12 @@ export const Basic: Story = () => {
 
 export const Horizontal: Story = () => {
 	const dragRef = React.useRef() as React.MutableRefObject<HTMLDivElement>;
-  const [dragElement, setDragElement] = React.useState<HTMLElement>();
+	const [dragElement, setDragElement] = React.useState<HTMLElement>();
 	const { isDragging, positionX, positionY } = useDrag(dragElement, "horizontal");
 
 	React.useEffect(() => {
-    setDragElement(dragRef.current);
-  }, []);
+		setDragElement(dragRef.current);
+	}, []);
 
 	return (
 		<div>
@@ -67,12 +67,12 @@ export const EndCallback: Story = () => {
 		alert(`Ended drag on: (${posX},${posY})`);
 	}
 	const dragRef = React.useRef() as React.MutableRefObject<HTMLDivElement>;
-  const [dragElement, setDragElement] = React.useState<HTMLElement>();
+	const [dragElement, setDragElement] = React.useState<HTMLElement>();
 	const { isDragging, positionX, positionY } = useDrag(dragElement, undefined, onDragEnd);
 
 	React.useEffect(() => {
-    setDragElement(dragRef.current);
-  }, []);
+		setDragElement(dragRef.current);
+	}, []);
 
 	return (
 		<div>

--- a/packages/dw-react-utils/src/stories/hooks/useDrag.stories.tsx
+++ b/packages/dw-react-utils/src/stories/hooks/useDrag.stories.tsx
@@ -66,6 +66,7 @@ export const EndCallback: Story = () => {
 	const onDragEnd = (posX: number, posY: number): void => {
 		alert(`Ended drag on: (${posX},${posY})`);
 	}
+
 	const dragRef = React.useRef() as React.MutableRefObject<HTMLDivElement>;
 	const [dragElement, setDragElement] = React.useState<HTMLElement>();
 	const { isDragging, positionX, positionY } = useDrag(dragElement, undefined, onDragEnd);

--- a/packages/dw-react-utils/src/stories/hooks/useDrag.stories.tsx
+++ b/packages/dw-react-utils/src/stories/hooks/useDrag.stories.tsx
@@ -3,87 +3,87 @@ import * as React from "react";
 import { useDrag } from "../../hooks";
 
 const dragItemStyles: React.CSSProperties = {
-	width: "50px",
-	height: "50px",
-	backgroundColor: "#a19f9d",
-	display: "flex",
-	alignItems: "center",
-	flexDirection: "row",
-	justifyContent: "center",
-	color: "white",
-	cursor: "move",
-	userSelect: "none",
-	position: "relative",
-	borderRadius: "50%",
-	boxShadow: "5px 5px 24px 0px rgba(0,0,0,0.50)"
+  width: "50px",
+  height: "50px",
+  backgroundColor: "#a19f9d",
+  display: "flex",
+  alignItems: "center",
+  flexDirection: "row",
+  justifyContent: "center",
+  color: "white",
+  cursor: "move",
+  userSelect: "none",
+  position: "relative",
+  borderRadius: "50%",
+  boxShadow: "5px 5px 24px 0px rgba(0,0,0,0.50)"
 }
 
 export const Basic: Story = () => {
-	const dragRef = React.useRef() as React.MutableRefObject<HTMLDivElement>;
-	const [dragElement, setDragElement] = React.useState<HTMLElement>();
-	const { isDragging, positionX, positionY } = useDrag(dragElement);
+  const dragRef = React.useRef() as React.MutableRefObject<HTMLDivElement>;
+  const [dragElement, setDragElement] = React.useState<HTMLElement>();
+  const { isDragging, positionX, positionY } = useDrag(dragElement);
 
-	React.useEffect(() => {
-		setDragElement(dragRef.current);
-	}, []);
+  React.useEffect(() => {
+    setDragElement(dragRef.current);
+  }, []);
 
-	return (
-		<div>
-			<div>
-				<div>Is dragging: {`${isDragging ? "Yes" : "No"}`}</div>
-				<div>Position (x, y): {`${positionX}, ${positionY}`}</div>
-			</div>
-			<div ref={dragRef} style={dragItemStyles}>
-				Drag
-			</div>
-		</div>
-	)
+  return (
+    <div>
+      <div>
+        <div>Is dragging: {`${isDragging ? "Yes" : "No"}`}</div>
+        <div>Position (x, y): {`${positionX}, ${positionY}`}</div>
+      </div>
+      <div ref={dragRef} style={dragItemStyles}>
+        Drag
+      </div>
+    </div>
+  )
 }
 
 export const Horizontal: Story = () => {
-	const dragRef = React.useRef() as React.MutableRefObject<HTMLDivElement>;
-	const [dragElement, setDragElement] = React.useState<HTMLElement>();
-	const { isDragging, positionX, positionY } = useDrag(dragElement, "horizontal");
+  const dragRef = React.useRef() as React.MutableRefObject<HTMLDivElement>;
+  const [dragElement, setDragElement] = React.useState<HTMLElement>();
+  const { isDragging, positionX, positionY } = useDrag(dragElement, "horizontal");
 
-	React.useEffect(() => {
-		setDragElement(dragRef.current);
-	}, []);
+  React.useEffect(() => {
+    setDragElement(dragRef.current);
+  }, []);
 
-	return (
-		<div>
-			<div>
-				<div>Is dragging: {`${isDragging ? "Yes" : "No"}`}</div>
-				<div>Position (x, y): {`${positionX}, ${positionY}`}</div>
-			</div>
-			<div ref={dragRef} style={dragItemStyles}>
-				Drag
-			</div>
-		</div>
-	)
+  return (
+    <div>
+      <div>
+        <div>Is dragging: {`${isDragging ? "Yes" : "No"}`}</div>
+        <div>Position (x, y): {`${positionX}, ${positionY}`}</div>
+      </div>
+      <div ref={dragRef} style={dragItemStyles}>
+        Drag
+      </div>
+    </div>
+  )
 }
 
 export const EndCallback: Story = () => {
-	const onDragEnd = (posX: number, posY: number): void => {
-		alert(`Ended drag on: (${posX},${posY})`);
-	}
+  const onDragEnd = (posX: number, posY: number): void => {
+    alert(`Ended drag on: (${posX},${posY})`);
+  }
 
-	const dragRef = React.useRef() as React.MutableRefObject<HTMLDivElement>;
-	const [dragElement, setDragElement] = React.useState<HTMLElement>();
-	const { isDragging, positionX, positionY } = useDrag(dragElement, undefined, onDragEnd);
+  const dragRef = React.useRef() as React.MutableRefObject<HTMLDivElement>;
+  const [dragElement, setDragElement] = React.useState<HTMLElement>();
+  const { isDragging, positionX, positionY } = useDrag(dragElement, undefined, onDragEnd);
 
-	React.useEffect(() => {
-		setDragElement(dragRef.current);
-	}, []);
+  React.useEffect(() => {
+    setDragElement(dragRef.current);
+  }, []);
 
-	return (
-		<div>
-			<div>
-				<div>Is dragging: {`${isDragging ? "Yes" : "No"}`}</div>
-				<div>Position (x, y): {`${positionX}, ${positionY}`}</div>
-			</div>
-			<div ref={dragRef} style={dragItemStyles}>
-				Drag
-			</div>
-		</div>
-	)
+  return (
+    <div>
+      <div>
+        <div>Is dragging: {`${isDragging ? "Yes" : "No"}`}</div>
+        <div>Position (x, y): {`${positionX}, ${positionY}`}</div>
+      </div>
+      <div ref={dragRef} style={dragItemStyles}>
+        Drag
+      </div>
+    </div>
+  )
 }

--- a/packages/dw-react-utils/src/stories/hooks/useDrag.stories.tsx
+++ b/packages/dw-react-utils/src/stories/hooks/useDrag.stories.tsx
@@ -1,0 +1,88 @@
+import { Story } from "@storybook/react";
+import * as React from "react";
+import { useDrag } from "../../hooks";
+
+const dragItemStyles: React.CSSProperties = {
+	width: "50px",
+	height: "50px",
+	backgroundColor: "#a19f9d",
+	display: "flex",
+	alignItems: "center",
+	flexDirection: "row",
+	justifyContent: "center",
+	color: "white",
+	cursor: "move",
+	userSelect: "none",
+	position: "relative",
+	borderRadius: "50%",
+	boxShadow: "5px 5px 24px 0px rgba(0,0,0,0.50)"
+}
+
+export const Basic: Story = () => {
+	const dragRef = React.useRef() as React.MutableRefObject<HTMLDivElement>;
+  const [dragElement, setDragElement] = React.useState<HTMLElement>();
+	const { isDragging, positionX, positionY } = useDrag(dragElement);
+
+	React.useEffect(() => {
+    setDragElement(dragRef.current);
+  }, []);
+
+	return (
+		<div>
+			<div>
+				<div>Is dragging: {`${isDragging ? "Yes" : "No"}`}</div>
+				<div>Position (x, y): {`${positionX}, ${positionY}`}</div>
+			</div>
+			<div ref={dragRef} style={dragItemStyles}>
+				Drag
+			</div>
+		</div>
+	)
+}
+
+export const Horizontal: Story = () => {
+	const dragRef = React.useRef() as React.MutableRefObject<HTMLDivElement>;
+  const [dragElement, setDragElement] = React.useState<HTMLElement>();
+	const { isDragging, positionX, positionY } = useDrag(dragElement, "horizontal");
+
+	React.useEffect(() => {
+    setDragElement(dragRef.current);
+  }, []);
+
+	return (
+		<div>
+			<div>
+				<div>Is dragging: {`${isDragging ? "Yes" : "No"}`}</div>
+				<div>Position (x, y): {`${positionX}, ${positionY}`}</div>
+			</div>
+			<div ref={dragRef} style={dragItemStyles}>
+				Drag
+			</div>
+		</div>
+	)
+}
+
+export const EndCallback: Story = () => {
+	const onDragEnd = (posX: number, posY: number): void => {
+		alert(`Ended drag on: (${posX},${posY})`);
+	}
+	const dragRef = React.useRef() as React.MutableRefObject<HTMLDivElement>;
+  const [dragElement, setDragElement] = React.useState<HTMLElement>();
+	const { isDragging, positionX, positionY } = useDrag(dragElement, undefined, onDragEnd);
+
+	React.useEffect(() => {
+    setDragElement(dragRef.current);
+  }, []);
+
+	return (
+		<div>
+			<div>
+				<div>Is dragging: {`${isDragging ? "Yes" : "No"}`}</div>
+				<div>Position (x, y): {`${positionX}, ${positionY}`}</div>
+			</div>
+			<div ref={dragRef} style={dragItemStyles}>
+				Drag
+			</div>
+		</div>
+	)
+}

--- a/packages/dw-react-utils/src/stories/hooks/useWindowEvent.stories.mdx
+++ b/packages/dw-react-utils/src/stories/hooks/useWindowEvent.stories.mdx
@@ -1,0 +1,28 @@
+import { Meta } from "@storybook/addon-docs";
+
+<Meta title="Utils/hooks/useWindowEvent" />
+
+# useWindowEvent
+
+The `useWindowEvent` hook provides an easy way to register events on the window object.
+The event will correctly be register and most importantly unregistered as well.
+
+As input the type of event and the callback is expected
+
+## Usage
+
+```tsx
+useWindowEvent("mousemove", (e: Event) => console.log((e as MouseEvent).pageX));
+```
+
+## Example
+
+```tsx
+const MyComponent = () => {
+	const [moveX, setMoveX] = React.useState(0);
+
+	useWindowEvent("mousemove", (e: Event) => setMoveX((e as MouseEvent).pageX));
+
+	return <div>Mouse Move X Position: {moveX}</div>;
+};
+```


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [ ] Component improvement
- [x] New component
- [ ] New package
- [ ] Other

## Description
This PR contains 2 new reusable hooks:
 - useWindowEvent: wrapper for the add and remove event listeners on the window object (is a helper hook for the useDrag hook)
 - useDrag: enables you to make an html element draggable. Can be useful when you have a movable badge on your page for example