### PR TITLE
task(WebPartTitle): Margin bottom uses theme.spacing.m

### DIFF
--- a/packages/dw-spfx-controls/src/components/WebPartTitle/WebPartTitle.styles.ts
+++ b/packages/dw-spfx-controls/src/components/WebPartTitle/WebPartTitle.styles.ts
@@ -18,7 +18,7 @@ export const getStyles = (props: IWebPartTitleStyleProps): IWebPartTitleStyles =
 				display: "flex",
 				flexDirection: "row",
 				justifyContent: "flex-end",
-				marginBottom: "18px",
+				marginBottom: theme.spacing.m,
 				marginTop: 0,
 				whiteSpace: "pre-wrap"
 			},


### PR DESCRIPTION
## Type of change

- [x] Other: task

## Description
Web part title should use themed spacing whenever possible, such that it correctly outlines next to other components that use themed spacing.


❤
