### PR TITLE
fix: peoplepicker updates

### DIFF
--- a/change/@dlw-digitalworkplace-dw-react-controls-ba97580c-643a-4719-b151-d0e32cf31678.json
+++ b/change/@dlw-digitalworkplace-dw-react-controls-ba97580c-643a-4719-b151-d0e32cf31678.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "don't pass 0 as itemlimit by default",
+  "packageName": "@dlw-digitalworkplace/dw-react-controls",
+  "email": "nick.sevens@delaware.pro",
+  "dependentChangeType": "patch"
+}

--- a/change/@dlw-digitalworkplace-peoplepickerprovider-graph-7c22bd6b-4ea3-49d2-bc90-9e48050adc7e.json
+++ b/change/@dlw-digitalworkplace-peoplepickerprovider-graph-7c22bd6b-4ea3-49d2-bc90-9e48050adc7e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "filter only on valid guids",
+  "packageName": "@dlw-digitalworkplace/peoplepickerprovider-graph",
+  "email": "nick.sevens@delaware.pro",
+  "dependentChangeType": "patch"
+}

--- a/change/@dlw-digitalworkplace-peoplepickerprovider-sharepoint-193529a3-ebb2-4233-a5e2-74569a462f14.json
+++ b/change/@dlw-digitalworkplace-peoplepickerprovider-sharepoint-193529a3-ebb2-4233-a5e2-74569a462f14.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "don't trim builting group ids",
+  "packageName": "@dlw-digitalworkplace/peoplepickerprovider-sharepoint",
+  "email": "nick.sevens@delaware.pro",
+  "dependentChangeType": "patch"
+}

--- a/packages/dw-react-controls/src/components/PeoplePicker/PeoplePicker.base.tsx
+++ b/packages/dw-react-controls/src/components/PeoplePicker/PeoplePicker.base.tsx
@@ -15,7 +15,7 @@ export const PeoplePickerBase: React.FC<IPeoplePickerProps> = ({
 	className,
 	errorMessage,
 	inputProps: inputPropsProp,
-	itemLimit = 0,
+	itemLimit,
 	label,
 	labelProps,
 	pickerSuggestionsProps,
@@ -35,7 +35,7 @@ export const PeoplePickerBase: React.FC<IPeoplePickerProps> = ({
 
 	// Check to see if the item limit is not exceeded
 	React.useEffect(() => {
-		setIsInvalid(itemLimit > 0 && itemLimit < selectedItems.length);
+		setIsInvalid(itemLimit !== undefined && itemLimit > -1 && itemLimit < selectedItems.length);
 	}, [itemLimit, selectedItems]);
 
 	// Keep track of focus state

--- a/packages/peoplePickerProviders/graph/src/GraphPeoplePickerProvider.ts
+++ b/packages/peoplePickerProviders/graph/src/GraphPeoplePickerProvider.ts
@@ -165,6 +165,10 @@ export class GraphPeoplePickerProvider implements IPeoplePickerProvider {
 			return "";
 		}
 
+		idsToIgnore = idsToIgnore.filter((id) =>
+			id.match(/^[{(]?[0-9A-F]{8}[-]?(?:[0-9A-F]{4}[-]?){3}[0-9A-F]{12}[)}]?$/gi)
+		);
+
 		const m365Clause = "groupTypes/any(g: g eq 'Unified')";
 		const securityClause = "not(groupTypes/any(g: g eq 'Unified')) AND securityEnabled eq true";
 		const distributionClause =

--- a/packages/peoplePickerProviders/sharepoint/src/SharePointPeoplePickerProvider.ts
+++ b/packages/peoplePickerProviders/sharepoint/src/SharePointPeoplePickerProvider.ts
@@ -196,7 +196,12 @@ export class SharePointPeoplePickerProvider implements IPeoplePickerProvider {
 
 			case "SecGroup":
 			case "FormsRole":
-				const groupId = result.Key.split("|").pop();
+				// leaves "special" groups as-is.
+				// - c:0(.s|true -- Everyone
+				// - c:0-.f|rolemanager|spo-grid-all-users/<<realm>> -- Everyone except external users
+				const builtinGroupsRegex = /^c:0((\(\.s\|true)|(-\.f\|rolemanager\|spo-grid-all-users\/[a-z0-9\-]*))$/i;
+
+				const groupId = builtinGroupsRegex.test(result.Key) ? result.Key : result.Key.split("|").pop();
 				const secGroup: IGroup = {
 					type: "Group",
 					id: groupId,
@@ -206,6 +211,7 @@ export class SharePointPeoplePickerProvider implements IPeoplePickerProvider {
 						entityType: result.EntityType
 					}
 				};
+
 				return secGroup;
 
 			case "SPGroup": {


### PR DESCRIPTION
## Type of change

- [x] Bugfix
- [ ] Component improvement
- [ ] New component
- [ ] New package
- [ ] Other

## Description

- Don't pass 0 as default item limit
- Filter graph search only on valid guids
- Don't trim out builtin group id prefixes