### PR TITLE
fix(SharePointTaxonomyProvider): option to (un)hide deprecated terms

### DIFF
--- a/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/DemoTaxonomyPickerWebPart.tsx
+++ b/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/DemoTaxonomyPickerWebPart.tsx
@@ -22,6 +22,7 @@ export default class DemoTaxonomyPickerWebPart extends BaseClientSideWebPart<IDe
 			<WebPartContext.Provider value={webPartContext}>
 				<DemoTaxonomyPicker
 					allowAddingTerms={this.properties.allowAddingTerms}
+					allowDeprecatedTerms={this.properties.allowDeprecatedTerms}
 					preCacheTerms={this.properties.preCacheTerms}
 					termSetIdOrName={this.properties.termSetIdOrName}
 				/>
@@ -51,6 +52,9 @@ export default class DemoTaxonomyPickerWebPart extends BaseClientSideWebPart<IDe
 								}),
 								PropertyPaneToggle("allowAddingTerms", {
 									label: strings.AllowAddingTermsFieldLabel
+								}),
+								PropertyPaneToggle("allowDeprecatedTerms", {
+									label: strings.AllowDeprecatedTerms
 								}),
 								PropertyPaneToggle("preCacheTerms", {
 									label: strings.PreCacheTermsFieldLabel

--- a/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/DemoTaxonomyPickerWebPart.types.ts
+++ b/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/DemoTaxonomyPickerWebPart.types.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 
 export interface IDemoTaxonomyPickerWebPartProps {
 	allowAddingTerms: boolean;
+	allowDeprecatedTerms: boolean;
 	preCacheTerms: boolean;
 	termSetIdOrName: string;
 }

--- a/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/components/DemoTaxonomyPicker.tsx
+++ b/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/components/DemoTaxonomyPicker.tsx
@@ -23,8 +23,8 @@ export const DemoTaxonomyPicker: React.FC<IDemoTaxonomyPickerProps> = (props) =>
 
 			console.log("Creating new provider...");
 
-			const spTaxonomyProvider = new SharePointTaxonomyProvider(siteUrl, termSetIdOrName, 1033, allowDeprecatedTerms);
-			await spTaxonomyProvider.initialize(preCacheTerms);
+			const spTaxonomyProvider = new SharePointTaxonomyProvider(siteUrl, termSetIdOrName);
+			await spTaxonomyProvider.initialize(preCacheTerms, { trimDeprecated: !allowDeprecatedTerms });
 
 			setProviderAllowsAddingTerms(spTaxonomyProvider.allowAddingTerms);
 

--- a/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/components/DemoTaxonomyPicker.tsx
+++ b/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/components/DemoTaxonomyPicker.tsx
@@ -6,7 +6,7 @@ import styles from "./DemoTaxonomyPicker.module.scss";
 import { IDemoTaxonomyPickerProps } from "./DemoTaxonomyPicker.types";
 
 export const DemoTaxonomyPicker: React.FC<IDemoTaxonomyPickerProps> = (props) => {
-	const { allowAddingTerms, preCacheTerms, termSetIdOrName } = props;
+	const { allowAddingTerms, allowDeprecatedTerms, preCacheTerms, termSetIdOrName } = props;
 
 	const { siteUrl } = React.useContext(WebPartContext);
 	const [selectedItems, setSelectedItems] = React.useState<ITermValue[]>([]);
@@ -23,7 +23,7 @@ export const DemoTaxonomyPicker: React.FC<IDemoTaxonomyPickerProps> = (props) =>
 
 			console.log("Creating new provider...");
 
-			const spTaxonomyProvider = new SharePointTaxonomyProvider(siteUrl, termSetIdOrName);
+			const spTaxonomyProvider = new SharePointTaxonomyProvider(siteUrl, termSetIdOrName, 1033, allowDeprecatedTerms);
 			await spTaxonomyProvider.initialize(preCacheTerms);
 
 			setProviderAllowsAddingTerms(spTaxonomyProvider.allowAddingTerms);
@@ -32,12 +32,13 @@ export const DemoTaxonomyPicker: React.FC<IDemoTaxonomyPickerProps> = (props) =>
 
 			setProvider(spTaxonomyProvider);
 		})();
-	}, [preCacheTerms, siteUrl, termSetIdOrName]);
+	}, [preCacheTerms, siteUrl, termSetIdOrName, allowDeprecatedTerms]);
 
 	return (
 		<div className={styles.demoTaxonomyPicker}>
 			<TaxonomyPicker
 				allowAddingTerms={allowAddingTerms && providerAllowsAddingTerms}
+				allowDeprecatedTerms={allowDeprecatedTerms}
 				disabled={!provider}
 				onChange={setSelectedItems}
 				provider={provider}

--- a/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/components/DemoTaxonomyPicker.types.ts
+++ b/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/components/DemoTaxonomyPicker.types.ts
@@ -1,5 +1,6 @@
 export interface IDemoTaxonomyPickerProps {
 	allowAddingTerms: boolean;
+	allowDeprecatedTerms: boolean;
 	preCacheTerms: boolean;
 	termSetIdOrName: string;
 }

--- a/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/loc/en-us.js
+++ b/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/loc/en-us.js
@@ -1,6 +1,7 @@
 define([], function () {
 	return {
 		AllowAddingTermsFieldLabel: "Allow adding terms?",
+		AllowDeprecatedTerms: "Allow deprecated terms?",
 		BasicGroupName: "General settings",
 		PreCacheTermsFieldLabel: "Pre-cache terms?",
 		TermSetIdOrNameFieldLabel: "Termset name or id"

--- a/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/loc/mystrings.d.ts
+++ b/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/loc/mystrings.d.ts
@@ -1,5 +1,6 @@
 declare interface IDemoTaxonomyPickerWebPartStrings {
 	AllowAddingTermsFieldLabel: string;
+	AllowDeprecatedTerms: string;
 	BasicGroupName: string;
 	PreCacheTermsFieldLabel: string;
 	TermSetIdOrNameFieldLabel: string;


### PR DESCRIPTION
## Type of change

- [x] Bugfix
- [ ] Component improvement
- [ ] New component
- [ ] New package
- [ ] Other

## Description
Add option to include deprecated terms (do not include by default)
