### PR TITLE
fix(SharePointTaxonomyProvider): add filter options on getTermTree

### DIFF
--- a/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/DemoTaxonomyPickerWebPart.tsx
+++ b/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/DemoTaxonomyPickerWebPart.tsx
@@ -22,6 +22,7 @@ export default class DemoTaxonomyPickerWebPart extends BaseClientSideWebPart<IDe
 			<WebPartContext.Provider value={webPartContext}>
 				<DemoTaxonomyPicker
 					allowAddingTerms={this.properties.allowAddingTerms}
+					allowDeprecatedTerms={this.properties.allowDeprecatedTerms}
 					preCacheTerms={this.properties.preCacheTerms}
 					termSetIdOrName={this.properties.termSetIdOrName}
 				/>
@@ -51,6 +52,9 @@ export default class DemoTaxonomyPickerWebPart extends BaseClientSideWebPart<IDe
 								}),
 								PropertyPaneToggle("allowAddingTerms", {
 									label: strings.AllowAddingTermsFieldLabel
+								}),
+								PropertyPaneToggle("allowDeprecatedTerms", {
+									label: strings.AllowDeprecatedTermsLabel
 								}),
 								PropertyPaneToggle("preCacheTerms", {
 									label: strings.PreCacheTermsFieldLabel

--- a/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/DemoTaxonomyPickerWebPart.types.ts
+++ b/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/DemoTaxonomyPickerWebPart.types.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 
 export interface IDemoTaxonomyPickerWebPartProps {
 	allowAddingTerms: boolean;
+	allowDeprecatedTerms: boolean;
 	preCacheTerms: boolean;
 	termSetIdOrName: string;
 }

--- a/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/components/DemoTaxonomyPicker.tsx
+++ b/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/components/DemoTaxonomyPicker.tsx
@@ -6,7 +6,7 @@ import styles from "./DemoTaxonomyPicker.module.scss";
 import { IDemoTaxonomyPickerProps } from "./DemoTaxonomyPicker.types";
 
 export const DemoTaxonomyPicker: React.FC<IDemoTaxonomyPickerProps> = (props) => {
-	const { allowAddingTerms, preCacheTerms, termSetIdOrName } = props;
+	const { allowAddingTerms, allowDeprecatedTerms, preCacheTerms, termSetIdOrName } = props;
 
 	const { siteUrl } = React.useContext(WebPartContext);
 	const [selectedItems, setSelectedItems] = React.useState<ITermValue[]>([]);
@@ -38,6 +38,7 @@ export const DemoTaxonomyPicker: React.FC<IDemoTaxonomyPickerProps> = (props) =>
 		<div className={styles.demoTaxonomyPicker}>
 			<TaxonomyPicker
 				allowAddingTerms={allowAddingTerms && providerAllowsAddingTerms}
+				allowDeprecatedTerms={allowDeprecatedTerms}
 				disabled={!provider}
 				onChange={setSelectedItems}
 				provider={provider}

--- a/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/components/DemoTaxonomyPicker.types.ts
+++ b/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/components/DemoTaxonomyPicker.types.ts
@@ -1,5 +1,6 @@
 export interface IDemoTaxonomyPickerProps {
 	allowAddingTerms: boolean;
+	allowDeprecatedTerms: boolean;
 	preCacheTerms: boolean;
 	termSetIdOrName: string;
 }

--- a/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/loc/en-us.js
+++ b/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/loc/en-us.js
@@ -1,6 +1,7 @@
 define([], function () {
 	return {
 		AllowAddingTermsFieldLabel: "Allow adding terms?",
+		AllowDeprecatedTermsLabel: "Allow deprecated terms?",
 		BasicGroupName: "General settings",
 		PreCacheTermsFieldLabel: "Pre-cache terms?",
 		TermSetIdOrNameFieldLabel: "Termset name or id"

--- a/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/loc/mystrings.d.ts
+++ b/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/loc/mystrings.d.ts
@@ -1,5 +1,6 @@
 declare interface IDemoTaxonomyPickerWebPartStrings {
 	AllowAddingTermsFieldLabel: string;
+	AllowDeprecatedTermsLabel: string;
 	BasicGroupName: string;
 	PreCacheTermsFieldLabel: string;
 	TermSetIdOrNameFieldLabel: string;

--- a/change/@dlw-digitalworkplace-dw-react-controls-5d0488bb-46e0-4193-be3b-0727c0a1e85f.json
+++ b/change/@dlw-digitalworkplace-dw-react-controls-5d0488bb-46e0-4193-be3b-0727c0a1e85f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(SharePointTaxonomyProvider): add filter options on getTermTree",
+  "packageName": "@dlw-digitalworkplace/dw-react-controls",
+  "email": "debeufk@delawareconsulting.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@dlw-digitalworkplace-taxonomyprovider-sharepoint-0fe3578d-047c-47d8-b427-e7d68b3f172a.json
+++ b/change/@dlw-digitalworkplace-taxonomyprovider-sharepoint-0fe3578d-047c-47d8-b427-e7d68b3f172a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(SharePointTaxonomyProvider): add filter options on getTermTree",
+  "packageName": "@dlw-digitalworkplace/taxonomyprovider-sharepoint",
+  "email": "debeufk@delawareconsulting.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.base.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.base.tsx
@@ -348,6 +348,8 @@ export const TaxonomyPickerBase: React.FC<ITaxonomyPickerProps> = ({
 					{...dialogProps}
 					provider={provider}
 					allowAddingTerms={allowAddingTerms}
+					allowDisabledTerms={allowDisabledTerms}
+					allowDeprecatedTerms={allowDeprecatedTerms}
 					defaultSelectedItems={selectedItems}
 					hidden={!dialogIsOpen}
 					itemLimit={itemLimit}

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.base.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.base.tsx
@@ -77,10 +77,15 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 
 	React.useEffect(() => {
 		(async () => {
-			const filterOptions: Partial<ITermFilterOptions> = {
-				trimDeprecated: !allowDeprecatedTerms,
-				trimUnavailable: !allowDisabledTerms
-			};
+			const filterOptions: Partial<ITermFilterOptions> = {};
+
+			if (allowDeprecatedTerms !== undefined) {
+				filterOptions.trimDeprecated = !allowDeprecatedTerms;
+			}
+
+			if (allowDisabledTerms !== undefined) {
+				filterOptions.trimUnavailable = !allowDisabledTerms;
+			}
 
 			const terms = rfdc()(await provider.getTermTree(filterOptions));
 

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.base.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.base.tsx
@@ -87,7 +87,7 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 			setTermTreeItems(terms);
 			setExpandedNodes(showRootNode ? [rootNodeKey] : terms && terms.length > 0 ? [terms[0].key] : []);
 		})();
-	}, [provider]);
+	}, [provider, showRootNode, rootNodeKey, allowDeprecatedTerms, allowDisabledTerms]);
 
 	React.useEffect(() => {
 		if (!termTreeItems) {

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.base.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.base.tsx
@@ -6,7 +6,7 @@ import { ITermValue, TermPicker } from "../../TermPicker";
 import { ITreeItemAction, TreeItem } from "../../TreeItem";
 import { TreeView } from "../../TreeView";
 import { WideDialog } from "../../WideDialog";
-import { ITerm, ITermCreationResult } from "../models";
+import { ITerm, ITermCreationResult, ITermFilterOptions } from "../models";
 import { TermAdder } from "../TermAdder";
 import {
 	ITaxonomyPickerDialogLabels,
@@ -23,6 +23,8 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 	const {
 		labels: labelsProp,
 		allowAddingTerms,
+		allowDisabledTerms,
+		allowDeprecatedTerms,
 		itemLimit,
 		showRootNode,
 		rootNodeLabel,
@@ -75,7 +77,12 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 
 	React.useEffect(() => {
 		(async () => {
-			const terms = rfdc()(await provider.getTermTree());
+			const filterOptions: Partial<ITermFilterOptions> = {
+				trimDeprecated: !allowDeprecatedTerms,
+				trimUnavailable: !allowDisabledTerms
+			};
+
+			const terms = rfdc()(await provider.getTermTree(filterOptions));
 
 			setTermTreeItems(terms);
 			setExpandedNodes(showRootNode ? [rootNodeKey] : terms && terms.length > 0 ? [terms[0].key] : []);

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.types.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.types.ts
@@ -15,6 +15,10 @@ export interface ITaxonomyPickerDialogLabels {
 interface ITaxonomyPickerDialogPropsBase {
 	allowAddingTerms?: boolean;
 
+	allowDisabledTerms?: boolean;
+
+	allowDeprecatedTerms?: boolean;
+
 	provider: ITaxonomyProvider;
 
 	showRootNode?: boolean;

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/models/ITaxonomyProvider.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/models/ITaxonomyProvider.ts
@@ -6,7 +6,7 @@ export interface ITaxonomyProvider {
 
 	findTerms(search?: string | RegExp, options?: Partial<ITermFilterOptions>): ITerm[] | PromiseLike<ITerm[]>;
 
-	getTermTree(): ITerm[] | PromiseLike<ITerm[]>;
+	getTermTree(options?: Partial<ITermFilterOptions>): ITerm[] | PromiseLike<ITerm[]>;
 
 	createTerm(newValue: string, parentId?: string): ITerm | PromiseLike<ITerm>;
 }


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [x] Component improvement
- [ ] New component
- [ ] New package
- [ ] Other

## Description
fix(SharePointTaxonomyProvider): add filter options on getTermTree
