### PR TITLE
fix: force sourcemap builds

### DIFF
--- a/change/@dlw-digitalworkplace-dw-react-utils-manual.json
+++ b/change/@dlw-digitalworkplace-dw-react-utils-manual.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add sourcemaps to package",
+  "packageName": "@dlw-digitalworkplace/dw-react-utils",
+  "email": "nick.sevens@delaware.pro",
+  "dependentChangeType": "none"
+}

--- a/change/@dlw-digitalworkplace-dw-refresh-cache-manual.json
+++ b/change/@dlw-digitalworkplace-dw-refresh-cache-manual.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add sourcemaps to package",
+  "packageName": "@dlw-digitalworkplace/dw-refresh-cache",
+  "email": "nick.sevens@delaware.pro",
+  "dependentChangeType": "none"
+}

--- a/change/@dlw-digitalworkplace-dw-spfx-controls-manual.json
+++ b/change/@dlw-digitalworkplace-dw-spfx-controls-manual.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: add sourcemaps to package",
+  "packageName": "@dlw-digitalworkplace/dw-spfx-controls",
+  "email": "nick.sevens@delaware.pro",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
## Type of change

- [x] Bugfix
- [ ] Component improvement
- [ ] New component
- [ ] New package
- [ ] Other

## Description

Add inline sourcemaps to build output 