### PR TITLE
Feature: add me/people endpoint to graphPeoplePickerProvider

### DIFF
--- a/apps/demo-spfx-app/config/package-solution.json
+++ b/apps/demo-spfx-app/config/package-solution.json
@@ -21,6 +21,10 @@
 			{
 				"resource": "Microsoft Graph",
 				"scope": "Group.Read.All"
+			},
+			{
+				"resource": "Microsoft Graph",
+				"scope": "People.Read.All"
 			}
 		]
 	},

--- a/apps/demo-spfx-app/src/webparts/demoPeoplePicker/DemoPeoplePickerWebPart.manifest.json
+++ b/apps/demo-spfx-app/src/webparts/demoPeoplePicker/DemoPeoplePickerWebPart.manifest.json
@@ -24,7 +24,8 @@
 			"officeFabricIconFontName": "Page",
 			"properties": {
 				"providerType": "MockProvider",
-				"itemLimit": 3
+				"itemLimit": 3,
+				"useMeEndpoint": false
 			}
 		}
 	]

--- a/apps/demo-spfx-app/src/webparts/demoPeoplePicker/DemoPeoplePickerWebPart.manifest.json
+++ b/apps/demo-spfx-app/src/webparts/demoPeoplePicker/DemoPeoplePickerWebPart.manifest.json
@@ -25,7 +25,7 @@
 			"properties": {
 				"providerType": "MockProvider",
 				"itemLimit": 3,
-				"useMeEndpoint": false
+				"usersEndpoint": "users"
 			}
 		}
 	]

--- a/apps/demo-spfx-app/src/webparts/demoPeoplePicker/DemoPeoplePickerWebPart.tsx
+++ b/apps/demo-spfx-app/src/webparts/demoPeoplePicker/DemoPeoplePickerWebPart.tsx
@@ -94,8 +94,8 @@ export default class DemoPeoplePickerWebPart extends BaseClientSideWebPart<IDemo
 									min: 1,
 									max: 10
 								}),
-								PropertyPaneDropdown("endpoint", {
-									label: "Which endpoint to use",
+								PropertyPaneDropdown("usersEndpoint", {
+									label: "Which endpoint to use to retrieve users",
 									options: [
 										{
 											key: "users",
@@ -106,7 +106,7 @@ export default class DemoPeoplePickerWebPart extends BaseClientSideWebPart<IDemo
 											text: "me/people"
 										}
 									],
-									selectedKey: this.properties.endpoint,
+									selectedKey: this.properties.usersEndpoint,
 									disabled: this.properties.providerType !== "GraphProvider"
 								})
 							]
@@ -125,7 +125,7 @@ export default class DemoPeoplePickerWebPart extends BaseClientSideWebPart<IDemo
 				const aadTokenProvider = await this.context.aadTokenProviderFactory.getTokenProvider();
 				const providerOptions: IGraphPeoplePickerProviderOptions = {
 					resourceTypes: ResourceType.User | ResourceType.Group,
-					endpoint: this.properties.endpoint
+					usersEndpoint: this.properties.usersEndpoint
 				};
 
 				this._provider = new GraphPeoplePickerProvider(

--- a/apps/demo-spfx-app/src/webparts/demoPeoplePicker/DemoPeoplePickerWebPart.tsx
+++ b/apps/demo-spfx-app/src/webparts/demoPeoplePicker/DemoPeoplePickerWebPart.tsx
@@ -10,7 +10,7 @@ import {
 	SharePointPeoplePickerProvider
 } from "@dlw-digitalworkplace/peoplepickerprovider-sharepoint";
 import { Version } from "@microsoft/sp-core-library";
-import { IPropertyPaneConfiguration, PropertyPaneChoiceGroup, PropertyPaneSlider } from "@microsoft/sp-property-pane";
+import { IPropertyPaneConfiguration, PropertyPaneChoiceGroup, PropertyPaneSlider, PropertyPaneToggle } from "@microsoft/sp-property-pane";
 import { BaseClientSideWebPart } from "@microsoft/sp-webpart-base";
 import * as strings from "DemoPeoplePickerWebPartStrings";
 import * as React from "react";
@@ -93,6 +93,11 @@ export default class DemoPeoplePickerWebPart extends BaseClientSideWebPart<IDemo
 									label: "Max. items",
 									min: 1,
 									max: 10
+								}),
+								PropertyPaneToggle("useMeEndpoint", {
+									label: "Use me/people endpoint",
+									checked: this.properties.useMeEndpoint,
+									disabled: this.properties.providerType !== "GraphProvider"
 								})
 							]
 						}
@@ -109,7 +114,8 @@ export default class DemoPeoplePickerWebPart extends BaseClientSideWebPart<IDemo
 			case "GraphProvider": {
 				const aadTokenProvider = await this.context.aadTokenProviderFactory.getTokenProvider();
 				const providerOptions: IGraphPeoplePickerProviderOptions = {
-					resourceTypes: ResourceType.User | ResourceType.Group
+					resourceTypes: ResourceType.User | ResourceType.Group,
+					findRelevantUsers: this.properties.useMeEndpoint
 				};
 
 				this._provider = new GraphPeoplePickerProvider(

--- a/apps/demo-spfx-app/src/webparts/demoPeoplePicker/DemoPeoplePickerWebPart.tsx
+++ b/apps/demo-spfx-app/src/webparts/demoPeoplePicker/DemoPeoplePickerWebPart.tsx
@@ -115,7 +115,7 @@ export default class DemoPeoplePickerWebPart extends BaseClientSideWebPart<IDemo
 				const aadTokenProvider = await this.context.aadTokenProviderFactory.getTokenProvider();
 				const providerOptions: IGraphPeoplePickerProviderOptions = {
 					resourceTypes: ResourceType.User | ResourceType.Group,
-					findRelevantUsers: this.properties.useMeEndpoint
+					useMeEndpoint: this.properties.useMeEndpoint
 				};
 
 				this._provider = new GraphPeoplePickerProvider(

--- a/apps/demo-spfx-app/src/webparts/demoPeoplePicker/DemoPeoplePickerWebPart.tsx
+++ b/apps/demo-spfx-app/src/webparts/demoPeoplePicker/DemoPeoplePickerWebPart.tsx
@@ -10,7 +10,7 @@ import {
 	SharePointPeoplePickerProvider
 } from "@dlw-digitalworkplace/peoplepickerprovider-sharepoint";
 import { Version } from "@microsoft/sp-core-library";
-import { IPropertyPaneConfiguration, PropertyPaneChoiceGroup, PropertyPaneDropdown, PropertyPaneSlider, PropertyPaneToggle } from "@microsoft/sp-property-pane";
+import { IPropertyPaneConfiguration, PropertyPaneChoiceGroup, PropertyPaneDropdown, PropertyPaneSlider } from "@microsoft/sp-property-pane";
 import { BaseClientSideWebPart } from "@microsoft/sp-webpart-base";
 import * as strings from "DemoPeoplePickerWebPartStrings";
 import * as React from "react";

--- a/apps/demo-spfx-app/src/webparts/demoPeoplePicker/DemoPeoplePickerWebPart.tsx
+++ b/apps/demo-spfx-app/src/webparts/demoPeoplePicker/DemoPeoplePickerWebPart.tsx
@@ -10,7 +10,7 @@ import {
 	SharePointPeoplePickerProvider
 } from "@dlw-digitalworkplace/peoplepickerprovider-sharepoint";
 import { Version } from "@microsoft/sp-core-library";
-import { IPropertyPaneConfiguration, PropertyPaneChoiceGroup, PropertyPaneSlider, PropertyPaneToggle } from "@microsoft/sp-property-pane";
+import { IPropertyPaneConfiguration, PropertyPaneChoiceGroup, PropertyPaneDropdown, PropertyPaneSlider, PropertyPaneToggle } from "@microsoft/sp-property-pane";
 import { BaseClientSideWebPart } from "@microsoft/sp-webpart-base";
 import * as strings from "DemoPeoplePickerWebPartStrings";
 import * as React from "react";
@@ -94,9 +94,19 @@ export default class DemoPeoplePickerWebPart extends BaseClientSideWebPart<IDemo
 									min: 1,
 									max: 10
 								}),
-								PropertyPaneToggle("useMeEndpoint", {
-									label: "Use me/people endpoint",
-									checked: this.properties.useMeEndpoint,
+								PropertyPaneDropdown("endpoint", {
+									label: "Which endpoint to use",
+									options: [
+										{
+											key: "users",
+											text: "users"
+										},
+										{
+											key: "me/people",
+											text: "me/people"
+										}
+									],
+									selectedKey: this.properties.endpoint,
 									disabled: this.properties.providerType !== "GraphProvider"
 								})
 							]
@@ -115,7 +125,7 @@ export default class DemoPeoplePickerWebPart extends BaseClientSideWebPart<IDemo
 				const aadTokenProvider = await this.context.aadTokenProviderFactory.getTokenProvider();
 				const providerOptions: IGraphPeoplePickerProviderOptions = {
 					resourceTypes: ResourceType.User | ResourceType.Group,
-					useMeEndpoint: this.properties.useMeEndpoint
+					endpoint: this.properties.endpoint
 				};
 
 				this._provider = new GraphPeoplePickerProvider(

--- a/apps/demo-spfx-app/src/webparts/demoPeoplePicker/DemoPeoplePickerWebPart.types.ts
+++ b/apps/demo-spfx-app/src/webparts/demoPeoplePicker/DemoPeoplePickerWebPart.types.ts
@@ -1,5 +1,5 @@
 export interface IDemoPeoplePickerWebPartProps {
 	itemLimit: number;
 	providerType: "GraphProvider" | "MockProvider" | "SharePointProvider";
-	useMeEndpoint: boolean;
+	endpoint: "users" | "me/people";
 }

--- a/apps/demo-spfx-app/src/webparts/demoPeoplePicker/DemoPeoplePickerWebPart.types.ts
+++ b/apps/demo-spfx-app/src/webparts/demoPeoplePicker/DemoPeoplePickerWebPart.types.ts
@@ -1,5 +1,5 @@
 export interface IDemoPeoplePickerWebPartProps {
 	itemLimit: number;
 	providerType: "GraphProvider" | "MockProvider" | "SharePointProvider";
-	endpoint: "users" | "me/people";
+	usersEndpoint: "users" | "me/people";
 }

--- a/apps/demo-spfx-app/src/webparts/demoPeoplePicker/DemoPeoplePickerWebPart.types.ts
+++ b/apps/demo-spfx-app/src/webparts/demoPeoplePicker/DemoPeoplePickerWebPart.types.ts
@@ -1,4 +1,5 @@
 export interface IDemoPeoplePickerWebPartProps {
 	itemLimit: number;
 	providerType: "GraphProvider" | "MockProvider" | "SharePointProvider";
+	useMeEndpoint: boolean;
 }

--- a/change/@dlw-digitalworkplace-peoplepickerprovider-graph-c5deb50a-4756-4f0b-916c-249fbfaf34b4.json
+++ b/change/@dlw-digitalworkplace-peoplepickerprovider-graph-c5deb50a-4756-4f0b-916c-249fbfaf34b4.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "Add possibility to search via me/people",
   "packageName": "@dlw-digitalworkplace/peoplepickerprovider-graph",
   "email": "torremansw@delawareconsulting.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "minor"
 }

--- a/change/@dlw-digitalworkplace-peoplepickerprovider-graph-c5deb50a-4756-4f0b-916c-249fbfaf34b4.json
+++ b/change/@dlw-digitalworkplace-peoplepickerprovider-graph-c5deb50a-4756-4f0b-916c-249fbfaf34b4.json
@@ -3,5 +3,5 @@
   "comment": "Add possibility to search via me/people",
   "packageName": "@dlw-digitalworkplace/peoplepickerprovider-graph",
   "email": "torremansw@delawareconsulting.com",
-  "dependentChangeType": "minor"
+  "dependentChangeType": "patch"
 }

--- a/change/@dlw-digitalworkplace-peoplepickerprovider-graph-c5deb50a-4756-4f0b-916c-249fbfaf34b4.json
+++ b/change/@dlw-digitalworkplace-peoplepickerprovider-graph-c5deb50a-4756-4f0b-916c-249fbfaf34b4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add possibility to search via me/people",
+  "packageName": "@dlw-digitalworkplace/peoplepickerprovider-graph",
+  "email": "torremansw@delawareconsulting.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/peoplePickerProviders/graph/src/GraphPeoplePickerProvider.ts
+++ b/packages/peoplePickerProviders/graph/src/GraphPeoplePickerProvider.ts
@@ -22,7 +22,7 @@ export class GraphPeoplePickerProvider implements IPeoplePickerProvider {
 
 	private readonly DEFAULTOPTIONS: Partial<IGraphPeoplePickerProviderOptions> = {
 		groupTypes: GroupType.M365 | GroupType.Security | GroupType.Distribution,
-		useMeEndpoint: false
+		endpoint: "users"
 	};
 
 	constructor(
@@ -79,7 +79,7 @@ export class GraphPeoplePickerProvider implements IPeoplePickerProvider {
 
 	private async _findUsers(search: string, options: IPeoplePickerFilterOptions): Promise<IUser[]> {
 		let searchClause = "";
-		if(!this._providerOptions.useMeEndpoint) {
+		if(this._providerOptions.endpoint === "users") {
 			searchClause += `"displayName:${search}"`;
 			searchClause += ` OR "userPrincipalName:${search}"`;
 			searchClause += ` OR "givenName:${search}"`;
@@ -102,7 +102,7 @@ export class GraphPeoplePickerProvider implements IPeoplePickerProvider {
 
 		const graphToken = await this._getGraphToken();
 		const userResponse = await fetch(
-			this._providerOptions.useMeEndpoint
+			this._providerOptions.endpoint === "me/people"
 				? `https://graph.microsoft.com/v1.0/me/people?$search=${searchClause}&$filter=${filterClause}&$count=true`
 				:	`https://graph.microsoft.com/v1.0/users?$search=${searchClause}&$filter=${filterClause}&$count=true`,
 			{

--- a/packages/peoplePickerProviders/graph/src/GraphPeoplePickerProvider.ts
+++ b/packages/peoplePickerProviders/graph/src/GraphPeoplePickerProvider.ts
@@ -22,7 +22,7 @@ export class GraphPeoplePickerProvider implements IPeoplePickerProvider {
 
 	private readonly DEFAULTOPTIONS: Partial<IGraphPeoplePickerProviderOptions> = {
 		groupTypes: GroupType.M365 | GroupType.Security | GroupType.Distribution,
-		endpoint: "users"
+		usersEndpoint: "users"
 	};
 
 	constructor(
@@ -79,7 +79,7 @@ export class GraphPeoplePickerProvider implements IPeoplePickerProvider {
 
 	private async _findUsers(search: string, options: IPeoplePickerFilterOptions): Promise<IUser[]> {
 		let searchClause = "";
-		if(this._providerOptions.endpoint === "users") {
+		if(this._providerOptions.usersEndpoint === "users") {
 			searchClause += `"displayName:${search}"`;
 			searchClause += ` OR "userPrincipalName:${search}"`;
 			searchClause += ` OR "givenName:${search}"`;
@@ -102,7 +102,7 @@ export class GraphPeoplePickerProvider implements IPeoplePickerProvider {
 
 		const graphToken = await this._getGraphToken();
 		const userResponse = await fetch(
-			this._providerOptions.endpoint === "me/people"
+			this._providerOptions.usersEndpoint === "me/people"
 				? `https://graph.microsoft.com/v1.0/me/people?$search=${searchClause}&$filter=${filterClause}&$count=true`
 				:	`https://graph.microsoft.com/v1.0/users?$search=${searchClause}&$filter=${filterClause}&$count=true`,
 			{

--- a/packages/peoplePickerProviders/graph/src/GraphPeoplePickerProvider.ts
+++ b/packages/peoplePickerProviders/graph/src/GraphPeoplePickerProvider.ts
@@ -21,7 +21,8 @@ export class GraphPeoplePickerProvider implements IPeoplePickerProvider {
 	private _providerOptions: IGraphPeoplePickerProviderOptions;
 
 	private readonly DEFAULTOPTIONS: Partial<IGraphPeoplePickerProviderOptions> = {
-		groupTypes: GroupType.M365 | GroupType.Security | GroupType.Distribution
+		groupTypes: GroupType.M365 | GroupType.Security | GroupType.Distribution,
+		useMeEndpoint: false
 	};
 
 	constructor(
@@ -78,11 +79,15 @@ export class GraphPeoplePickerProvider implements IPeoplePickerProvider {
 
 	private async _findUsers(search: string, options: IPeoplePickerFilterOptions): Promise<IUser[]> {
 		let searchClause = "";
-		searchClause += `"displayName:${search}"`;
-		searchClause += ` OR "userPrincipalName:${search}"`;
-		searchClause += ` OR "givenName:${search}"`;
-		searchClause += ` OR "surname:${search}"`;
-		searchClause += ` OR "mail:${search}"`;
+		if(!this._providerOptions.useMeEndpoint) {
+			searchClause += `"displayName:${search}"`;
+			searchClause += ` OR "userPrincipalName:${search}"`;
+			searchClause += ` OR "givenName:${search}"`;
+			searchClause += ` OR "surname:${search}"`;
+			searchClause += ` OR "mail:${search}"`;
+		} else {
+			searchClause += search;
+		}
 
 		const idsToIgnore = options.idsToIgnore.filter((id) =>
 			id.match(/^[{(]?[0-9A-F]{8}[-]?(?:[0-9A-F]{4}[-]?){3}[0-9A-F]{12}[)}]?$/gi)
@@ -97,7 +102,9 @@ export class GraphPeoplePickerProvider implements IPeoplePickerProvider {
 
 		const graphToken = await this._getGraphToken();
 		const userResponse = await fetch(
-			`https://graph.microsoft.com/v1.0/users?$search=${searchClause}&$filter=${filterClause}&$count=true`,
+			this._providerOptions.useMeEndpoint
+				? `https://graph.microsoft.com/v1.0/me/people?$search=${searchClause}&$filter=${filterClause}&$count=true`
+				:	`https://graph.microsoft.com/v1.0/users?$search=${searchClause}&$filter=${filterClause}&$count=true`,
 			{
 				headers: {
 					ConsistencyLevel: "Eventual",

--- a/packages/peoplePickerProviders/graph/src/models/IGraphPeoplePickerProviderOptions.ts
+++ b/packages/peoplePickerProviders/graph/src/models/IGraphPeoplePickerProviderOptions.ts
@@ -14,7 +14,7 @@ export interface IGraphPeoplePickerProviderOptions {
 	groupTypes?: GroupType;
 
 	/**
-	 * Specifies what endpoint nthe provider should use, either /me/people or /users
+	 * Specifies what endpoint the provider should use, either /me/people or /users
 	 */
 	useMeEndpoint?: boolean;
 }

--- a/packages/peoplePickerProviders/graph/src/models/IGraphPeoplePickerProviderOptions.ts
+++ b/packages/peoplePickerProviders/graph/src/models/IGraphPeoplePickerProviderOptions.ts
@@ -12,4 +12,9 @@ export interface IGraphPeoplePickerProviderOptions {
 	 * @default GroupType.M365 | GroupType.Security | GroupType.Distribution
 	 */
 	groupTypes?: GroupType;
+
+	/**
+	 * Specifies what endpoint nthe provider should use, either /me/people or /users
+	 */
+	useMeEndpoint?: boolean;
 }

--- a/packages/peoplePickerProviders/graph/src/models/IGraphPeoplePickerProviderOptions.ts
+++ b/packages/peoplePickerProviders/graph/src/models/IGraphPeoplePickerProviderOptions.ts
@@ -14,7 +14,7 @@ export interface IGraphPeoplePickerProviderOptions {
 	groupTypes?: GroupType;
 
 	/**
-	 * Specifies what endpoint the provider should use, either /me/people or /users
+	 * Specifies what endpoint the provider should use to retrieve users, either /me/people or /users
 	 */
-	endpoint?: "users" | "me/people";
+	usersEndpoint?: "users" | "me/people";
 }

--- a/packages/peoplePickerProviders/graph/src/models/IGraphPeoplePickerProviderOptions.ts
+++ b/packages/peoplePickerProviders/graph/src/models/IGraphPeoplePickerProviderOptions.ts
@@ -16,5 +16,5 @@ export interface IGraphPeoplePickerProviderOptions {
 	/**
 	 * Specifies what endpoint the provider should use, either /me/people or /users
 	 */
-	useMeEndpoint?: boolean;
+	endpoint?: "users" | "me/people";
 }

--- a/packages/peoplePickerProviders/graph/src/stories/GraphPeoplePickerProvider.stories.mdx
+++ b/packages/peoplePickerProviders/graph/src/stories/GraphPeoplePickerProvider.stories.mdx
@@ -22,7 +22,7 @@ import { GraphPeoplePickerProvider, GroupType, ResourceType } from "@dlw-digital
 const provider = new GraphPeoplePickerProvider(graphToken, {
 	resourceTypes: ResourceType.User | ResourceType.Group,
 	groupTypes: GroupType.M365 | GroupType.Security | GroupType.Distribution, /* optional */
-	useMeEndpoint: true | false /* optional */
+	endpoint: "users" | "me/people" /* optional */
 });
 
 // or with a function to retrieve the Graph token
@@ -30,7 +30,7 @@ const provider = new GraphPeoplePickerProvider(graphToken, {
 const provider = new GraphPeoplePickerProvider(() => aadTokenProvider.getToken("https://graph.microsoft.com"), {
 	resourceTypes: ResourceType.User | ResourceType.Group,
 	groupTypes: GroupType.M365 | GroupType.Security | GroupType.Distribution, /* optional */
-	useMeEndpoint: true | false /* optional */
+	endpoint: "users" | "me/people" /* optional */
 });
 ```
 
@@ -59,7 +59,7 @@ Creates a new `GraphPeoplePickerProvider` object.
 | ---------------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------- |
 | resourceTypes<span class="req">\*</span> | `ResourceType` | The type(s) of resources to search for.                                                                          |
 | groupTypes                               | `GroupType`    | If `Group` is specified in the `resourceTypes`, then this property specifies the type(s) of group to search for. |
-| endpoint                                 | `"users" | "me/people"`      | Specifies what endpoint the provider should use, either /me/people or /users                                     |
+| endpoint                                 | `"users"` &#124; `"me/people"`      | Specifies what endpoint the provider should use, either /me/people or /users                                     |
 
 ### `ResourceType`
 

--- a/packages/peoplePickerProviders/graph/src/stories/GraphPeoplePickerProvider.stories.mdx
+++ b/packages/peoplePickerProviders/graph/src/stories/GraphPeoplePickerProvider.stories.mdx
@@ -22,7 +22,7 @@ import { GraphPeoplePickerProvider, GroupType, ResourceType } from "@dlw-digital
 const provider = new GraphPeoplePickerProvider(graphToken, {
 	resourceTypes: ResourceType.User | ResourceType.Group,
 	groupTypes: GroupType.M365 | GroupType.Security | GroupType.Distribution, /* optional */
-	endpoint: "users" // or: "me/people" /* optional */
+	usersEndpoint: "users" // or: "me/people" /* optional */
 });
 
 // or with a function to retrieve the Graph token
@@ -30,7 +30,7 @@ const provider = new GraphPeoplePickerProvider(graphToken, {
 const provider = new GraphPeoplePickerProvider(() => aadTokenProvider.getToken("https://graph.microsoft.com"), {
 	resourceTypes: ResourceType.User | ResourceType.Group,
 	groupTypes: GroupType.M365 | GroupType.Security | GroupType.Distribution, /* optional */
-	endpoint: "users" // or: "me/people" /* optional */
+	usersEndpoint: "users" // or: "me/people" /* optional */
 });
 ```
 
@@ -59,7 +59,7 @@ Creates a new `GraphPeoplePickerProvider` object.
 | ---------------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------- |
 | resourceTypes<span class="req">\*</span> | `ResourceType` | The type(s) of resources to search for.                                                                          |
 | groupTypes                               | `GroupType`    | If `Group` is specified in the `resourceTypes`, then this property specifies the type(s) of group to search for. |
-| endpoint                                 | `"users"` &#124; `"me/people"`      | Specifies what endpoint the provider should use, either /me/people or /users                                     |
+| usersEndpoint                            | `"users"` &#124; `"me/people"`      | Specifies what endpoint the provider should use to retrieve users, either /me/people or /users. |
 
 ### `ResourceType`
 

--- a/packages/peoplePickerProviders/graph/src/stories/GraphPeoplePickerProvider.stories.mdx
+++ b/packages/peoplePickerProviders/graph/src/stories/GraphPeoplePickerProvider.stories.mdx
@@ -21,14 +21,16 @@ import { GraphPeoplePickerProvider, GroupType, ResourceType } from "@dlw-digital
 
 const provider = new GraphPeoplePickerProvider(graphToken, {
 	resourceTypes: ResourceType.User | ResourceType.Group,
-	groupTypes: GroupType.M365 | GroupType.Security | GroupType.Distribution /* optional */
+	groupTypes: GroupType.M365 | GroupType.Security | GroupType.Distribution, /* optional */
+	useMeEndpoint: true | false /* optional */
 });
 
 // or with a function to retrieve the Graph token
 
 const provider = new GraphPeoplePickerProvider(() => aadTokenProvider.getToken("https://graph.microsoft.com"), {
 	resourceTypes: ResourceType.User | ResourceType.Group,
-	groupTypes: GroupType.M365 | GroupType.Security | GroupType.Distribution /* optional */
+	groupTypes: GroupType.M365 | GroupType.Security | GroupType.Distribution, /* optional */
+	useMeEndpoint: true | false /* optional */
 });
 ```
 
@@ -57,6 +59,7 @@ Creates a new `GraphPeoplePickerProvider` object.
 | ---------------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------- |
 | resourceTypes<span class="req">\*</span> | `ResourceType` | The type(s) of resources to search for.                                                                          |
 | groupTypes                               | `GroupType`    | If `Group` is specified in the `resourceTypes`, then this property specifies the type(s) of group to search for. |
+| useMeEndpoint                            | `boolean`      | Specifies what endpoint the provider should use, either /me/people or /users                                     |
 
 ### `ResourceType`
 

--- a/packages/peoplePickerProviders/graph/src/stories/GraphPeoplePickerProvider.stories.mdx
+++ b/packages/peoplePickerProviders/graph/src/stories/GraphPeoplePickerProvider.stories.mdx
@@ -59,7 +59,7 @@ Creates a new `GraphPeoplePickerProvider` object.
 | ---------------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------- |
 | resourceTypes<span class="req">\*</span> | `ResourceType` | The type(s) of resources to search for.                                                                          |
 | groupTypes                               | `GroupType`    | If `Group` is specified in the `resourceTypes`, then this property specifies the type(s) of group to search for. |
-| useMeEndpoint                            | `boolean`      | Specifies what endpoint the provider should use, either /me/people or /users                                     |
+| endpoint                                 | `"users" | "me/people"`      | Specifies what endpoint the provider should use, either /me/people or /users                                     |
 
 ### `ResourceType`
 

--- a/packages/peoplePickerProviders/graph/src/stories/GraphPeoplePickerProvider.stories.mdx
+++ b/packages/peoplePickerProviders/graph/src/stories/GraphPeoplePickerProvider.stories.mdx
@@ -22,7 +22,7 @@ import { GraphPeoplePickerProvider, GroupType, ResourceType } from "@dlw-digital
 const provider = new GraphPeoplePickerProvider(graphToken, {
 	resourceTypes: ResourceType.User | ResourceType.Group,
 	groupTypes: GroupType.M365 | GroupType.Security | GroupType.Distribution, /* optional */
-	endpoint: "users" | "me/people" /* optional */
+	endpoint: "users" // or: "me/people" /* optional */
 });
 
 // or with a function to retrieve the Graph token
@@ -30,7 +30,7 @@ const provider = new GraphPeoplePickerProvider(graphToken, {
 const provider = new GraphPeoplePickerProvider(() => aadTokenProvider.getToken("https://graph.microsoft.com"), {
 	resourceTypes: ResourceType.User | ResourceType.Group,
 	groupTypes: GroupType.M365 | GroupType.Security | GroupType.Distribution, /* optional */
-	endpoint: "users" | "me/people" /* optional */
+	endpoint: "users" // or: "me/people" /* optional */
 });
 ```
 


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [x] Component improvement
- [ ] New component
- [ ] New package
- [ ] Other

## Description

This PR is linked to issue 59 (https://github.com/dlw-digitalworkplace/dw-component-lib/issues/59)
I've added an extra option in the GraphPeoplePickerProviderOptions so the user can change what endpoint needs to be used to search for people, either me/people or /users.


❤ Thank you for contributing!
