### PR TITLE
Bugs/react18 children prop

### DIFF
--- a/change/@dlw-digitalworkplace-dw-react-controls-327c5c17-a45e-4309-92b9-0059223cb210.json
+++ b/change/@dlw-digitalworkplace-dw-react-controls-327c5c17-a45e-4309-92b9-0059223cb210.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added explicit children prop for TreeView and TreeItem",
+  "packageName": "@dlw-digitalworkplace/dw-react-controls",
+  "email": "robin.agten@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/dw-react-controls/src/components/TreeItem/TreeItem.types.ts
+++ b/packages/dw-react-controls/src/components/TreeItem/TreeItem.types.ts
@@ -3,6 +3,11 @@ import { ITreeItemContentProps } from "./TreeItemContent";
 
 export interface ITreeItemProps {
 	/**
+	 * Optional react node children to render
+	 */
+	children?: React.ReactNode;
+
+	/**
 	 * Actions which are available on the tree item
 	 */
 	actions?: ITreeItemAction[];

--- a/packages/dw-react-controls/src/components/TreeView/TreeView.types.ts
+++ b/packages/dw-react-controls/src/components/TreeView/TreeView.types.ts
@@ -2,6 +2,11 @@ import { IStyle, IStyleFunctionOrObject, ITheme } from "@fluentui/react";
 
 interface ITreeViewPropsBase {
 	/**
+	 * Optional react node children to render
+	 */
+	children?: React.ReactNode;
+
+	/**
 	 * Expanded node ids (uncontrolled)
 	 */
 	defaultExpanded?: string[];


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [ ] Component improvement
- [ ] New component
- [ ] New package
- [ ] Other

## Description
https://github.com/dlw-digitalworkplace/dw-component-lib/issues/79
In React v18 the children prop is not added implicitly anymore. Therefor the TreeView and TreeItem cannot contain children anymore. This PR fixes this by explicitly adding the `children?: React.ReactNode;` prop to the TreeView and TreeItem
