### PR TITLE
feat(taxonomyPicker): alternative rendering

### DIFF
--- a/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/components/DemoTaxonomyPicker.tsx
+++ b/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/components/DemoTaxonomyPicker.tsx
@@ -1,4 +1,9 @@
-import { ITaxonomyProvider, ITermValue, TaxonomyPicker } from "@dlw-digitalworkplace/dw-react-controls";
+import {
+	ITaxonomyProvider,
+	ITermValue,
+	TaxonomyPicker,
+	TermItemSuggestion
+} from "@dlw-digitalworkplace/dw-react-controls";
 import { SharePointTaxonomyProvider } from "@dlw-digitalworkplace/taxonomyprovider-sharepoint";
 import * as React from "react";
 import { WebPartContext } from "../DemoTaxonomyPickerWebPart.types";
@@ -50,6 +55,32 @@ export const DemoTaxonomyPicker: React.FC<IDemoTaxonomyPickerProps> = (props) =>
 					},
 					rootNodeLabel: "Terms",
 					showRootNode: true
+				}}
+				termPickerProps={{
+					onRenderSuggestionsItem: (props) => (
+						<TermItemSuggestion
+							term={props}
+							onRenderLabel={(props) => {
+								return <div>{props.term.name}!</div>;
+							}}
+							onRenderSubText={(props) => {
+								const synonyms: { value: string }[] = props.term?.additionalProperties?.synonyms || [];
+
+								return (
+									synonyms.length > 0 && (
+										<div>
+											<small>
+												{synonyms
+													.filter((it) => it.value !== props.term.name)
+													.map((it) => it.value)
+													.join(", ")}
+											</small>
+										</div>
+									)
+								);
+							}}
+						/>
+					)
 				}}
 			/>
 		</div>

--- a/change/@dlw-digitalworkplace-dw-react-controls-de0cb0b2-091b-49b7-b6b4-bc0a224a00d3.json
+++ b/change/@dlw-digitalworkplace-dw-react-controls-de0cb0b2-091b-49b7-b6b4-bc0a224a00d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "allow alternative suggestion item rendering",
+  "packageName": "@dlw-digitalworkplace/dw-react-controls",
+  "email": "nick.sevens@delaware.pro",
+  "dependentChangeType": "patch"
+}

--- a/change/@dlw-digitalworkplace-taxonomyprovider-sharepoint-7dcbbb4c-8371-4fb0-8bb2-d699e23e53e9.json
+++ b/change/@dlw-digitalworkplace-taxonomyprovider-sharepoint-7dcbbb4c-8371-4fb0-8bb2-d699e23e53e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add synonyms to term output",
+  "packageName": "@dlw-digitalworkplace/taxonomyprovider-sharepoint",
+  "email": "nick.sevens@delaware.pro",
+  "dependentChangeType": "patch"
+}

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.base.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.base.tsx
@@ -1,15 +1,14 @@
 import { useId, useStateIfMounted } from "@dlw-digitalworkplace/dw-react-utils";
 import {
-	classNamesFunction,
-	composeRenderFunction,
-	IconButton,
 	IRenderFunction,
+	IconButton,
 	Label,
-	ValidationState
+	ValidationState,
+	classNamesFunction,
+	composeRenderFunction
 } from "@fluentui/react";
 import * as React from "react";
 import { ITermValue, TermPicker } from "../TermPicker";
-import { ITerm, ITermCreationResult, ITermFilterOptions } from "./models";
 import {
 	ITaxonomyPickerDialogButtonProps,
 	ITaxonomyPickerProps,
@@ -17,6 +16,7 @@ import {
 	ITaxonomyPickerStyles
 } from "./TaxonomyPicker.types";
 import { TaxonomyPickerDialog } from "./TaxonomyPickerDialog";
+import { ITerm, ITermCreationResult, ITermFilterOptions } from "./models";
 
 const getClassNames = classNamesFunction<ITaxonomyPickerStyleProps, ITaxonomyPickerStyles>();
 const tempItemKey = "__TEMP__ITEM__";
@@ -41,6 +41,7 @@ export const TaxonomyPickerBase: React.FC<ITaxonomyPickerProps> = ({
 	onRenderOpenDialogButton,
 	required,
 	styles,
+	termPickerProps,
 	theme
 }) => {
 	const [dialogIsOpen, setDialogIsOpen] = React.useState(false);
@@ -332,6 +333,7 @@ export const TaxonomyPickerBase: React.FC<ITaxonomyPickerProps> = ({
 					onResolveSuggestions={onResolveSuggestions}
 					onValidateInput={onValidateInput}
 					selectedItems={selectedItems}
+					{...termPickerProps}
 				/>
 				{finalOnRenderOpenDialogButton({
 					disabled: !!disabled,
@@ -356,7 +358,10 @@ export const TaxonomyPickerBase: React.FC<ITaxonomyPickerProps> = ({
 					onCreateNewTerm={handleCreateTermInDialog}
 					onConfirm={handleDialogConfirm}
 					onDismiss={handleDialogDismiss}
-					pickerProps={{ onResolveSuggestions: doResolveSuggestions }}
+					pickerProps={{
+						onResolveSuggestions: doResolveSuggestions,
+						...termPickerProps
+					}}
 				/>
 			)}
 		</div>

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
@@ -1,7 +1,7 @@
 import { ILabelProps, IRenderFunction, IStyle, IStyleFunctionOrObject, ITheme } from "@fluentui/react";
-import { ITermValue } from "../TermPicker";
-import { ITaxonomyProvider } from "./models";
+import { ITermPickerProps, ITermValue } from "../TermPicker";
 import { ITaxonomyPickerDialogProps } from "./TaxonomyPickerDialog";
+import { ITaxonomyProvider } from "./models";
 
 export interface ITaxonomyPickerProps {
 	allowAddingTerms?: boolean;
@@ -10,38 +10,40 @@ export interface ITaxonomyPickerProps {
 
 	allowDisabledTerms?: boolean;
 
-	provider: ITaxonomyProvider;
+	/**
+	 * Optional class for the root TaxonomyPicker element
+	 */
+	className?: string;
 
-	itemLimit?: number;
-
-	disabled?: boolean;
-
-	label?: string;
-
-	labelProps?: Partial<ILabelProps>;
+	errorMessage?: string | JSX.Element;
 
 	dialogProps?: Pick<
 		ITaxonomyPickerDialogProps,
 		"labels" | "showRootNode" | "rootNodeLabel" | "styles" | "className" | "dialogContentProps"
 	>;
 
+	disabled?: boolean;
+
+	itemLimit?: number;
+
+	label?: string;
+
+	labelProps?: Partial<ILabelProps>;
+
+	provider: ITaxonomyProvider;
+
 	required?: boolean;
 
 	selectedItems: ITermValue[];
-
-	/**
-	 * Optional class for the root TaxonomyPicker element
-	 */
-	className?: string;
 
 	/**
 	 * Call to apply custom styling on the TaxonomyPicker element
 	 */
 	styles?: IStyleFunctionOrObject<ITaxonomyPickerStyleProps, ITaxonomyPickerStyles>;
 
-	theme?: ITheme;
+	termPickerProps?: Pick<ITermPickerProps, "onRenderSuggestionsItem">;
 
-	errorMessage?: string | JSX.Element;
+	theme?: ITheme;
 
 	onRenderOpenDialogButton?: IRenderFunction<ITaxonomyPickerDialogButtonProps>;
 

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.base.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.base.tsx
@@ -1,13 +1,13 @@
 import { findInTree, flatten } from "@dlw-digitalworkplace/dw-react-utils";
-import { ActionButton, classNamesFunction, DefaultButton, DialogFooter, PrimaryButton } from "@fluentui/react";
+import { ActionButton, DefaultButton, DialogFooter, PrimaryButton, classNamesFunction } from "@fluentui/react";
 import * as React from "react";
 import * as rfdc from "rfdc";
 import { ITermValue, TermPicker } from "../../TermPicker";
 import { ITreeItemAction, TreeItem } from "../../TreeItem";
 import { TreeView } from "../../TreeView";
 import { WideDialog } from "../../WideDialog";
-import { ITerm, ITermCreationResult, ITermFilterOptions } from "../models";
 import { TermAdder } from "../TermAdder";
+import { ITerm, ITermCreationResult, ITermFilterOptions } from "../models";
 import {
 	ITaxonomyPickerDialogLabels,
 	ITaxonomyPickerDialogProps,
@@ -236,6 +236,7 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 
 		return (
 			<TreeView
+				disabledChildrenEnabled={true}
 				expanded={expandedNodes}
 				selected={selectedTreeItem}
 				onNodeSelect={handleTreeSelection}

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/models/ITerm.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/models/ITerm.ts
@@ -1,9 +1,6 @@
-import { ITermValue } from "../../TermPicker";
+import { ITermInfo } from "../../TermPicker";
 
-export interface ITerm extends ITermValue {
+export interface ITerm extends ITermInfo {
 	children?: ITerm[];
 	disabled?: boolean;
-	additionalProperties?: {
-		[key: string]: any;
-	};
 }

--- a/packages/dw-react-controls/src/components/TermPicker/TermItemSuggestion/TermItemSuggestion.base.tsx
+++ b/packages/dw-react-controls/src/components/TermPicker/TermItemSuggestion/TermItemSuggestion.base.tsx
@@ -1,4 +1,4 @@
-import { classNamesFunction } from "@fluentui/react";
+import { IRenderFunction, classNamesFunction, composeRenderFunction } from "@fluentui/react";
 import * as React from "react";
 import {
 	ITermItemSuggestionProps,
@@ -8,19 +8,35 @@ import {
 
 const getClassNames = classNamesFunction<ITermItemSuggestionStyleProps, ITermItemSuggestionStyles>();
 
-export const TermItemSuggestionBase: React.FC<ITermItemSuggestionProps> = ({ term, styles, theme }) => {
+export const TermItemSuggestionBase: React.FC<ITermItemSuggestionProps> = (props) => {
+	const { onRenderLabel, onRenderSubText } = props;
+	const { className, styles, theme } = props;
+
 	const classNames = getClassNames(styles, {
+		className,
 		theme: theme!
 	});
 
+	const renderLabel: IRenderFunction<ITermItemSuggestionProps> = (props?: ITermItemSuggestionProps) => {
+		return <div>{props?.term?.name}</div>;
+	};
+
+	const finalOnRenderLabel = onRenderLabel ? composeRenderFunction(onRenderLabel, renderLabel) : renderLabel;
+
+	const renderSubText: IRenderFunction<ITermItemSuggestionProps> = (props?: ITermItemSuggestionProps) => {
+		return props?.term?.path ? (
+			<div>
+				<small>{props.term.path}</small>
+			</div>
+		) : null;
+	};
+
+	const finalOnRenderSubText = onRenderSubText ? composeRenderFunction(onRenderSubText, renderSubText) : renderSubText;
+
 	return (
 		<div className={classNames.root}>
-			<div>{term?.name}</div>
-			{term?.path && (
-				<div>
-					<small>{term?.path}</small>
-				</div>
-			)}
+			{finalOnRenderLabel(props)}
+			{finalOnRenderSubText(props)}
 		</div>
 	);
 };

--- a/packages/dw-react-controls/src/components/TermPicker/TermItemSuggestion/TermItemSuggestion.types.ts
+++ b/packages/dw-react-controls/src/components/TermPicker/TermItemSuggestion/TermItemSuggestion.types.ts
@@ -1,8 +1,12 @@
-import { IStyle, IStyleFunctionOrObject, ITheme } from "@fluentui/react";
-import { ITermValue } from "../models";
+import { IRenderFunction, IStyle, IStyleFunctionOrObject, ITheme } from "@fluentui/react";
+import { ITermInfo } from "../models";
 
 export interface ITermItemSuggestionProps extends React.AllHTMLAttributes<HTMLElement> {
-	term?: ITermValue;
+	onRenderLabel?: IRenderFunction<ITermItemSuggestionProps>;
+
+	onRenderSubText?: IRenderFunction<ITermItemSuggestionProps>;
+
+	term?: ITermInfo;
 
 	/**
 	 * Optional class for the root TaxonomyPicker element

--- a/packages/dw-react-controls/src/components/TermPicker/TermPicker.base.tsx
+++ b/packages/dw-react-controls/src/components/TermPicker/TermPicker.base.tsx
@@ -1,6 +1,6 @@
 import { BasePicker, initializeComponentRef, IPickerItemProps } from "@fluentui/react";
 import * as React from "react";
-import { ITermValue } from "./models";
+import { ITermInfo, ITermValue } from "./models";
 import { TermItem } from "./TermItem";
 import { TermItemSuggestion } from "./TermItemSuggestion";
 import { ITermPickerProps } from "./TermPicker.types";
@@ -8,7 +8,7 @@ import { ITermPickerProps } from "./TermPicker.types";
 export class TermPickerBase extends BasePicker<ITermValue, ITermPickerProps> {
 	public static defaultProps: Partial<ITermPickerProps> = {
 		onRenderItem: (props: IPickerItemProps<ITermValue>) => <TermItem {...props}>{props.item.name}</TermItem>,
-		onRenderSuggestionsItem: (props: ITermValue) => <TermItemSuggestion term={props} />,
+		onRenderSuggestionsItem: (props: ITermInfo) => <TermItemSuggestion term={props} />,
 		pickerSuggestionsProps: {
 			loadingText: "Searching...",
 			noResultsFoundText: "No results found.",

--- a/packages/dw-react-controls/src/components/TermPicker/models/ITermInfo.ts
+++ b/packages/dw-react-controls/src/components/TermPicker/models/ITermInfo.ts
@@ -1,0 +1,5 @@
+import { ITermValue } from "./ITermValue";
+
+export interface ITermInfo extends ITermValue {
+	additionalProperties?: { [key: string]: any };
+}

--- a/packages/dw-react-controls/src/components/TermPicker/models/index.ts
+++ b/packages/dw-react-controls/src/components/TermPicker/models/index.ts
@@ -1,1 +1,2 @@
+export * from "./ITermInfo";
 export * from "./ITermValue";

--- a/packages/taxonomyProviders/sharepoint/src/SharePointTaxonomyProvider.ts
+++ b/packages/taxonomyProviders/sharepoint/src/SharePointTaxonomyProvider.ts
@@ -260,7 +260,14 @@ export class SharePointTaxonomyProvider implements ITaxonomyProvider {
 			path: input.get_pathOfTerm(),
 			disabled: !input.get_isAvailableForTagging() || input.get_isDeprecated(),
 			additionalProperties: {
-				deprecated: input.get_isDeprecated()
+				deprecated: input.get_isDeprecated(),
+				synonyms: input
+					.get_labels()
+					.get_data()
+					.map((it) => ({
+						language: it.get_language(),
+						value: it.get_value()
+					}))
 			}
 		};
 


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [x] Component improvement
- [ ] New component
- [ ] New package
- [ ] Other

## Description

Allow custom rendering for suggestions and term tree, to e.g. enable showing synonyms instead of term path
