### PR TITLE
feat(taxonomyPicker): allow overriding TreeItem rendering in TaxonomyPicker dialog

### DIFF
--- a/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/components/DemoTaxonomyPicker.tsx
+++ b/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/components/DemoTaxonomyPicker.tsx
@@ -1,5 +1,6 @@
 import {
 	ITaxonomyProvider,
+	ITermInfo,
 	ITermValue,
 	TaxonomyPicker,
 	TermItemSuggestion
@@ -39,6 +40,14 @@ export const DemoTaxonomyPicker: React.FC<IDemoTaxonomyPickerProps> = (props) =>
 		})();
 	}, [preCacheTerms, siteUrl, termSetIdOrName]);
 
+	const getTermSynonyms: (term: ITermInfo) => string[] = (term) => {
+		const synonyms: { value: string }[] = (term?.additionalProperties?.synonyms || []).filter(
+			(it) => it.value !== term.name
+		);
+
+		return synonyms.map((it) => it.value);
+	};
+
 	return (
 		<div className={styles.demoTaxonomyPicker}>
 			<TaxonomyPicker
@@ -54,27 +63,37 @@ export const DemoTaxonomyPicker: React.FC<IDemoTaxonomyPickerProps> = (props) =>
 						subText: "Browse the list of terms in the termset."
 					},
 					rootNodeLabel: "Terms",
-					showRootNode: true
+					showRootNode: true,
+					onRenderTreeItem: (props, defaultRender) => {
+						return defaultRender({
+							...props,
+							onRenderLabelContent: (labelProps, defaultLabelRender) => {
+								const synonyms = getTermSynonyms(props.term);
+
+								return (
+									<>
+										{defaultLabelRender(labelProps)}
+										{synonyms.length > 0 && <small>({synonyms.join(", ")})</small>}
+									</>
+								);
+							}
+						});
+					}
 				}}
 				termPickerProps={{
 					onRenderSuggestionsItem: (props) => (
 						<TermItemSuggestion
 							term={props}
 							onRenderLabel={(props) => {
-								return <div>{props.term.name}!</div>;
+								return <div>{props.term.name}</div>;
 							}}
 							onRenderSubText={(props) => {
-								const synonyms: { value: string }[] = props.term?.additionalProperties?.synonyms || [];
+								const synonyms = getTermSynonyms(props.term);
 
 								return (
 									synonyms.length > 0 && (
 										<div>
-											<small>
-												{synonyms
-													.filter((it) => it.value !== props.term.name)
-													.map((it) => it.value)
-													.join(", ")}
-											</small>
+											<small>{synonyms.join(", ")}</small>
 										</div>
 									)
 								);

--- a/change/@dlw-digitalworkplace-dw-react-controls-1b11e0ff-184d-4541-a69f-f35cfb7dbdac.json
+++ b/change/@dlw-digitalworkplace-dw-react-controls-1b11e0ff-184d-4541-a69f-f35cfb7dbdac.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add ability to override TreeItem rendering in TaxonomyPicker dialog",
+  "packageName": "@dlw-digitalworkplace/dw-react-controls",
+  "email": "nick.sevens@delaware.pro",
+  "dependentChangeType": "patch"
+}

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
@@ -19,7 +19,7 @@ export interface ITaxonomyPickerProps {
 
 	dialogProps?: Pick<
 		ITaxonomyPickerDialogProps,
-		"labels" | "showRootNode" | "rootNodeLabel" | "styles" | "className" | "dialogContentProps"
+		"className" | "dialogContentProps" | "labels" | "onRenderTreeItem" | "rootNodeLabel" | "showRootNode" | "styles"
 	>;
 
 	disabled?: boolean;

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.base.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.base.tsx
@@ -299,16 +299,20 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 			);
 		}
 
-		return renderTreeItem({
-			actions: treeItemActions,
-			children: children,
-			disabled: term.disabled,
-			iconName: term.disabled ? "TagSolid" : "Tag",
-			label: term.name,
-			nodeId: term.key,
-			onInvoke: handleNodeInvoke,
-			term: term
-		});
+		return (
+			<React.Fragment key={term.key}>
+				{renderTreeItem({
+					actions: treeItemActions,
+					children: children,
+					disabled: term.disabled,
+					iconName: term.disabled ? "TagSolid" : "Tag",
+					label: term.name,
+					nodeId: term.key,
+					onInvoke: handleNodeInvoke,
+					term: term
+				})}
+			</React.Fragment>
+		);
 	};
 
 	const defaultRenderTreeItem: IRenderFunction<ITreeItemProps & { term?: ITerm }> = (

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.base.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.base.tsx
@@ -1,9 +1,17 @@
 import { findInTree, flatten } from "@dlw-digitalworkplace/dw-react-utils";
-import { ActionButton, DefaultButton, DialogFooter, PrimaryButton, classNamesFunction } from "@fluentui/react";
+import {
+	ActionButton,
+	DefaultButton,
+	DialogFooter,
+	IRenderFunction,
+	PrimaryButton,
+	classNamesFunction,
+	composeRenderFunction
+} from "@fluentui/react";
 import * as React from "react";
 import * as rfdc from "rfdc";
 import { ITermValue, TermPicker } from "../../TermPicker";
-import { ITreeItemAction, TreeItem } from "../../TreeItem";
+import { ITreeItemAction, ITreeItemProps, TreeItem } from "../../TreeItem";
 import { TreeView } from "../../TreeView";
 import { WideDialog } from "../../WideDialog";
 import { TermAdder } from "../TermAdder";
@@ -35,6 +43,7 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 		onCreateNewTerm,
 		onConfirm,
 		onDismiss,
+		onRenderTreeItem,
 		provider,
 		styles,
 		theme,
@@ -259,7 +268,7 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 		);
 	};
 
-	const renderTreeNode = (term: ITerm): JSX.Element => {
+	const renderTreeNode = (term: ITerm): JSX.Element | null => {
 		const handleNodeInvoke = (event: React.MouseEvent<HTMLElement>) => {
 			event.stopPropagation();
 
@@ -290,20 +299,29 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 			);
 		}
 
-		return (
-			<TreeItem
-				key={term.key}
-				nodeId={term.key}
-				label={term.name}
-				disabled={term.disabled}
-				iconName={term.disabled ? "TagSolid" : "Tag"}
-				onInvoke={handleNodeInvoke}
-				actions={treeItemActions}
-			>
-				{children}
-			</TreeItem>
-		);
+		return renderTreeItem({
+			actions: treeItemActions,
+			children: children,
+			disabled: term.disabled,
+			iconName: term.disabled ? "TagSolid" : "Tag",
+			label: term.name,
+			nodeId: term.key,
+			onInvoke: handleNodeInvoke,
+			term: term
+		});
 	};
+
+	const defaultRenderTreeItem: IRenderFunction<ITreeItemProps & { term?: ITerm }> = (
+		treeItemProps: ITreeItemProps & { term: ITerm }
+	) => {
+		const { term, ...treeItemRest } = treeItemProps;
+
+		return <TreeItem {...treeItemRest} />;
+	};
+
+	const renderTreeItem = onRenderTreeItem
+		? composeRenderFunction(onRenderTreeItem, defaultRenderTreeItem)
+		: defaultRenderTreeItem;
 
 	return (
 		<WideDialog

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.types.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.types.ts
@@ -1,7 +1,8 @@
-import { IDialogProps, IStyle, IStyleFunctionOrObject, ITheme } from "@fluentui/react";
+import { IDialogProps, IRenderFunction, IStyle, IStyleFunctionOrObject, ITheme } from "@fluentui/react";
 import { ITermPickerProps, ITermValue } from "../../TermPicker";
-import { ITaxonomyProvider, ITermCreationResult } from "../models";
+import { ITreeItemProps } from "../../TreeItem";
 import { ITermAdderLabels } from "../TermAdder";
+import { ITaxonomyProvider, ITerm, ITermCreationResult } from "../models";
 
 export interface ITaxonomyPickerDialogLabels {
 	okButton?: string;
@@ -32,6 +33,11 @@ interface ITaxonomyPickerDialogPropsBase {
 	itemLimit?: number;
 
 	labels?: ITaxonomyPickerDialogLabels;
+
+	/**
+	 * When specified it will override the default rendering of the tree items
+	 */
+	onRenderTreeItem?: IRenderFunction<ITreeItemProps & { term?: ITerm }>;
 
 	/**
 	 * Call to apply custom styling on the TaxonomyPicker element

--- a/packages/dw-react-controls/src/components/TreeItem/TreeItem.base.tsx
+++ b/packages/dw-react-controls/src/components/TreeItem/TreeItem.base.tsx
@@ -16,19 +16,7 @@ const getClassNames = classNamesFunction<ITreeItemStyleProps, ITreeItemStyles>()
 const ownerDocument = (element: Node | null | undefined): Document => (element && element.ownerDocument) || document;
 
 export const TreeItemBase: React.FC<ITreeItemProps> = React.forwardRef<HTMLLIElement, ITreeItemProps>((props, ref) => {
-	const {
-		actions,
-		children,
-		disabled: disabledProp,
-		iconName,
-		id: idProp,
-		label,
-		nodeId,
-		onClick,
-		onInvoke,
-		onRenderContent,
-		onRenderLabel
-	} = props;
+	const { children, disabled: disabledProp, id: idProp, label, nodeId, onRenderContent } = props;
 	const { className, styles, theme } = props;
 
 	const {
@@ -112,6 +100,8 @@ export const TreeItemBase: React.FC<ITreeItemProps> = React.forwardRef<HTMLLIEle
 	};
 
 	const defaultRenderContent: IRenderFunction<ITreeItemProps> = (contentProps: ITreeItemProps) => {
+		const { actions, iconName, label, nodeId, onClick, onInvoke, onRenderLabel, onRenderLabelContent } = contentProps;
+
 		return (
 			<TreeItemContent
 				actions={actions}
@@ -121,6 +111,7 @@ export const TreeItemBase: React.FC<ITreeItemProps> = React.forwardRef<HTMLLIEle
 				onClick={onClick}
 				onInvoke={onInvoke}
 				onRenderLabel={onRenderLabel}
+				onRenderLabelContent={onRenderLabelContent}
 			/>
 		);
 	};

--- a/packages/dw-react-controls/src/components/TreeItem/TreeItem.types.ts
+++ b/packages/dw-react-controls/src/components/TreeItem/TreeItem.types.ts
@@ -47,6 +47,11 @@ export interface ITreeItemProps {
 	onRenderLabel?: IRenderFunction<ITreeItemContentProps>;
 
 	/**
+	 * When specified it will override the default rendering of the node label content
+	 */
+	onRenderLabelContent?: IRenderFunction<ITreeItemContentProps>;
+
+	/**
 	 * Optional class for the root TreeItem element
 	 */
 	className?: string;

--- a/packages/dw-react-controls/src/components/TreeItem/TreeItemContent/TreeItemContent.base.tsx
+++ b/packages/dw-react-controls/src/components/TreeItem/TreeItemContent/TreeItemContent.base.tsx
@@ -17,7 +17,7 @@ export const TreeItemContentBase: React.FC<ITreeItemContentProps> = React.forwar
 	HTMLDivElement,
 	ITreeItemContentProps
 >((props, ref) => {
-	const { actions, iconName, nodeId, onClick, onInvoke, onMouseDown, onRenderLabel } = props;
+	const { actions, nodeId, onClick, onInvoke, onMouseDown, onRenderLabel, onRenderLabelContent } = props;
 	const { disabled, expandable, expanded, focused, handleExpansion, handleSelection, preventSelection, selected } =
 		useTreeItem(nodeId);
 
@@ -81,17 +81,27 @@ export const TreeItemContentBase: React.FC<ITreeItemContentProps> = React.forwar
 	const defaultRenderLabel: IRenderFunction<ITreeItemContentProps> = (
 		contentProps: ITreeItemContentProps
 	): JSX.Element => {
-		const { label } = contentProps;
-
-		return (
-			<div className={classNames.labelWrapper}>
-				{iconName && <Icon iconName={iconName} />}
-				<div className={classNames.label}>{label}</div>
-			</div>
-		);
+		return <div className={classNames.labelWrapper}>{renderLabelContent(contentProps)}</div>;
 	};
 
 	const renderLabel = onRenderLabel ? composeRenderFunction(onRenderLabel, defaultRenderLabel) : defaultRenderLabel;
+
+	const defaultRenderLabelContent: IRenderFunction<ITreeItemContentProps> = (
+		contentProps: ITreeItemContentProps
+	): JSX.Element => {
+		const { label, iconName } = contentProps;
+
+		return (
+			<>
+				{iconName && <Icon iconName={iconName} />}
+				<div className={classNames.label}>{label}</div>
+			</>
+		);
+	};
+
+	const renderLabelContent = onRenderLabelContent
+		? composeRenderFunction(onRenderLabelContent, defaultRenderLabelContent)
+		: defaultRenderLabelContent;
 
 	return (
 		<div

--- a/packages/dw-react-controls/src/components/TreeItem/TreeItemContent/TreeItemContent.types.ts
+++ b/packages/dw-react-controls/src/components/TreeItem/TreeItemContent/TreeItemContent.types.ts
@@ -50,6 +50,11 @@ export interface ITreeItemContentProps {
 	onRenderLabel?: IRenderFunction<ITreeItemContentProps>;
 
 	/**
+	 * When specified it will override the default rendering of the node label content
+	 */
+	onRenderLabelContent?: IRenderFunction<ITreeItemContentProps>;
+
+	/**
 	 * Optional class for the root TreeItemContent element
 	 */
 	className?: string;


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [x] Component improvement
- [ ] New component
- [ ] New package
- [ ] Other

## Description

add the ability to override TreeItem rendering in TaxonomyPicker dialog.
