### PR TITLE
fix: improve handling disabled terms in term tree (BREAKING!)

### DIFF
--- a/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/DemoTaxonomyPickerWebPart.tsx
+++ b/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/DemoTaxonomyPickerWebPart.tsx
@@ -1,12 +1,12 @@
 import { Version } from "@microsoft/sp-core-library";
-import { SPComponentLoader } from "@microsoft/sp-loader";
+import { ILoadScriptOptions, SPComponentLoader } from "@microsoft/sp-loader";
 import { IPropertyPaneConfiguration, PropertyPaneTextField, PropertyPaneToggle } from "@microsoft/sp-property-pane";
 import { BaseClientSideWebPart } from "@microsoft/sp-webpart-base";
 import * as strings from "DemoTaxonomyPickerWebPartStrings";
 import * as React from "react";
 import * as ReactDom from "react-dom";
-import { DemoTaxonomyPicker } from "./components/DemoTaxonomyPicker";
 import { IDemoTaxonomyPickerWebPartProps, IWebPartContext, WebPartContext } from "./DemoTaxonomyPickerWebPart.types";
+import { DemoTaxonomyPicker } from "./components/DemoTaxonomyPicker";
 
 export default class DemoTaxonomyPickerWebPart extends BaseClientSideWebPart<IDemoTaxonomyPickerWebPartProps> {
 	protected async onInit(): Promise<void> {
@@ -23,6 +23,9 @@ export default class DemoTaxonomyPickerWebPart extends BaseClientSideWebPart<IDe
 				<DemoTaxonomyPicker
 					allowAddingTerms={this.properties.allowAddingTerms}
 					allowDeprecatedTerms={this.properties.allowDeprecatedTerms}
+					allowDisabledTerms={this.properties.allowDisabledTerms}
+					showDeprecatedTerms={this.properties.showDeprecatedTerms}
+					showDisabledTerms={this.properties.showDisabledTerms}
 					preCacheTerms={this.properties.preCacheTerms}
 					termSetIdOrName={this.properties.termSetIdOrName}
 				/>
@@ -56,6 +59,15 @@ export default class DemoTaxonomyPickerWebPart extends BaseClientSideWebPart<IDe
 								PropertyPaneToggle("allowDeprecatedTerms", {
 									label: strings.AllowDeprecatedTermsLabel
 								}),
+								PropertyPaneToggle("allowDisabledTerms", {
+									label: strings.AllowDisabledTermsLabel
+								}),
+								PropertyPaneToggle("showDeprecatedTerms", {
+									label: strings.ShowDeprecatedTermsLabel
+								}),
+								PropertyPaneToggle("showDisabledTerms", {
+									label: strings.ShowDisabledTermsLabel
+								}),
 								PropertyPaneToggle("preCacheTerms", {
 									label: strings.PreCacheTermsFieldLabel
 								})
@@ -68,12 +80,19 @@ export default class DemoTaxonomyPickerWebPart extends BaseClientSideWebPart<IDe
 	}
 
 	private async _loadSPDependencies(): Promise<void> {
-		const siteUrl = this.context.pageContext.site.serverRelativeUrl;
+		const loadScript = (url: string, options?: ILoadScriptOptions): Promise<unknown> => {
+			let siteUrl = this.context.pageContext.site.serverRelativeUrl;
+			siteUrl = siteUrl.endsWith("/") ? siteUrl.substring(0, siteUrl.length - 1) : siteUrl;
 
-		await SPComponentLoader.loadScript(`${siteUrl}/_layouts/15/init.js`, { globalExportsName: "$_global_init" });
-		await SPComponentLoader.loadScript(`${siteUrl}/_layouts/15/MicrosoftAjax.js`, { globalExportsName: "Sys" });
-		await SPComponentLoader.loadScript(`${siteUrl}/_layouts/15/SP.Runtime.js`, { globalExportsName: "SP" });
-		await SPComponentLoader.loadScript(`${siteUrl}/_layouts/15/SP.js`, { globalExportsName: "SP" });
-		await SPComponentLoader.loadScript(`${siteUrl}/_layouts/15/SP.Taxonomy.js`, { globalExportsName: "SP" });
+			url = url.startsWith("/") ? url.substring(1) : url;
+
+			return SPComponentLoader.loadScript(`${siteUrl}/${url}`, options);
+		};
+
+		await loadScript("/_layouts/15/init.js", { globalExportsName: "$_global_init" });
+		await loadScript("/_layouts/15/MicrosoftAjax.js", { globalExportsName: "Sys" });
+		await loadScript("/_layouts/15/SP.Runtime.js", { globalExportsName: "SP" });
+		await loadScript("/_layouts/15/SP.js", { globalExportsName: "SP" });
+		await loadScript("/_layouts/15/SP.Taxonomy.js", { globalExportsName: "SP" });
 	}
 }

--- a/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/DemoTaxonomyPickerWebPart.types.ts
+++ b/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/DemoTaxonomyPickerWebPart.types.ts
@@ -3,7 +3,10 @@ import * as React from "react";
 export interface IDemoTaxonomyPickerWebPartProps {
 	allowAddingTerms: boolean;
 	allowDeprecatedTerms: boolean;
+	allowDisabledTerms: boolean;
 	preCacheTerms: boolean;
+	showDeprecatedTerms: boolean;
+	showDisabledTerms: boolean;
 	termSetIdOrName: string;
 }
 

--- a/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/components/DemoTaxonomyPicker.tsx
+++ b/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/components/DemoTaxonomyPicker.tsx
@@ -12,7 +12,15 @@ import styles from "./DemoTaxonomyPicker.module.scss";
 import { IDemoTaxonomyPickerProps } from "./DemoTaxonomyPicker.types";
 
 export const DemoTaxonomyPicker: React.FC<IDemoTaxonomyPickerProps> = (props) => {
-	const { allowAddingTerms, allowDeprecatedTerms, preCacheTerms, termSetIdOrName } = props;
+	const {
+		allowAddingTerms,
+		allowDeprecatedTerms,
+		allowDisabledTerms,
+		preCacheTerms,
+		showDeprecatedTerms,
+		showDisabledTerms,
+		termSetIdOrName
+	} = props;
 
 	const { siteUrl } = React.useContext(WebPartContext);
 	const [selectedItems, setSelectedItems] = React.useState<ITermValue[]>([]);
@@ -52,7 +60,8 @@ export const DemoTaxonomyPicker: React.FC<IDemoTaxonomyPickerProps> = (props) =>
 		<div className={styles.demoTaxonomyPicker}>
 			<TaxonomyPicker
 				allowAddingTerms={allowAddingTerms && providerAllowsAddingTerms}
-				allowDeprecatedTerms={allowDeprecatedTerms}
+				allowDeprecatedTermSelection={allowDeprecatedTerms}
+				allowDisabledTermSelection={allowDisabledTerms}
 				disabled={!provider}
 				onChange={setSelectedItems}
 				provider={provider}
@@ -64,6 +73,8 @@ export const DemoTaxonomyPicker: React.FC<IDemoTaxonomyPickerProps> = (props) =>
 					},
 					rootNodeLabel: "Terms",
 					showRootNode: true,
+					trimDeprecatedTerms: !showDeprecatedTerms,
+					trimUnavailableTerms: !showDisabledTerms,
 					onRenderTreeItem: (props, defaultRender) => {
 						return defaultRender({
 							...props,

--- a/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/components/DemoTaxonomyPicker.types.ts
+++ b/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/components/DemoTaxonomyPicker.types.ts
@@ -1,6 +1,9 @@
 export interface IDemoTaxonomyPickerProps {
 	allowAddingTerms: boolean;
 	allowDeprecatedTerms: boolean;
+	allowDisabledTerms: boolean;
+	showDeprecatedTerms: boolean;
+	showDisabledTerms: boolean;
 	preCacheTerms: boolean;
 	termSetIdOrName: string;
 }

--- a/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/loc/en-us.js
+++ b/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/loc/en-us.js
@@ -1,9 +1,12 @@
 define([], function () {
 	return {
 		AllowAddingTermsFieldLabel: "Allow adding terms?",
-		AllowDeprecatedTermsLabel: "Allow deprecated terms?",
+		AllowDeprecatedTermsLabel: "Allow deprecated term selection?",
+		AllowDisabledTermsLabel: "Allow disabled term selection?",
 		BasicGroupName: "General settings",
 		PreCacheTermsFieldLabel: "Pre-cache terms?",
+		ShowDeprecatedTermsLabel: "Show deprecated terms in treeview?",
+		ShowDisabledTermsLabel: "Show disabled terms in treeview?",
 		TermSetIdOrNameFieldLabel: "Termset name or id"
 	};
 });

--- a/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/loc/mystrings.d.ts
+++ b/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/loc/mystrings.d.ts
@@ -1,8 +1,11 @@
 declare interface IDemoTaxonomyPickerWebPartStrings {
 	AllowAddingTermsFieldLabel: string;
 	AllowDeprecatedTermsLabel: string;
+	AllowDisabledTermsLabel: string;
 	BasicGroupName: string;
 	PreCacheTermsFieldLabel: string;
+	ShowDeprecatedTermsLabel: string;
+	ShowDisabledTermsLabel: string;
 	TermSetIdOrNameFieldLabel: string;
 }
 

--- a/change/@dlw-digitalworkplace-dw-react-controls-858629aa-7b09-47b6-9dbe-bab27021208a.json
+++ b/change/@dlw-digitalworkplace-dw-react-controls-858629aa-7b09-47b6-9dbe-bab27021208a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "improve handling disabled terms in term tree (BREAKING!)",
+  "packageName": "@dlw-digitalworkplace/dw-react-controls",
+  "email": "nick.sevens@delaware.pro",
+  "dependentChangeType": "patch"
+}

--- a/change/@dlw-digitalworkplace-taxonomyprovider-sharepoint-24d9a4e8-b043-47cf-91f0-30a42c05fba0.json
+++ b/change/@dlw-digitalworkplace-taxonomyprovider-sharepoint-24d9a4e8-b043-47cf-91f0-30a42c05fba0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix handling disabled terms in term tree",
+  "packageName": "@dlw-digitalworkplace/taxonomyprovider-sharepoint",
+  "email": "nick.sevens@delaware.pro",
+  "dependentChangeType": "patch"
+}

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.base.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.base.tsx
@@ -25,6 +25,8 @@ export const TaxonomyPickerBase: React.FC<ITaxonomyPickerProps> = ({
 	allowAddingTerms,
 	allowDeprecatedTerms,
 	allowDisabledTerms,
+	allowDeprecatedTermSelection = allowDeprecatedTerms,
+	allowDisabledTermSelection = allowDisabledTerms,
 	className,
 	disabled,
 	errorMessage: errorMessageProp,
@@ -139,8 +141,8 @@ export const TaxonomyPickerBase: React.FC<ITaxonomyPickerProps> = ({
 
 		const findOptions: Partial<ITermFilterOptions> = {
 			keysToIgnore: currentSelection?.map((it) => it.key),
-			trimDeprecated: !allowDeprecatedTerms,
-			trimUnavailable: !allowDisabledTerms
+			trimDeprecated: !allowDeprecatedTermSelection,
+			trimUnavailable: !allowDisabledTermSelection
 		};
 
 		// retrieve the available terms
@@ -350,8 +352,6 @@ export const TaxonomyPickerBase: React.FC<ITaxonomyPickerProps> = ({
 					{...dialogProps}
 					provider={provider}
 					allowAddingTerms={allowAddingTerms}
-					allowDisabledTerms={allowDisabledTerms}
-					allowDeprecatedTerms={allowDeprecatedTerms}
 					defaultSelectedItems={selectedItems}
 					hidden={!dialogIsOpen}
 					itemLimit={itemLimit}

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
@@ -6,9 +6,18 @@ import { ITaxonomyProvider } from "./models";
 export interface ITaxonomyPickerProps {
 	allowAddingTerms?: boolean;
 
+	/**
+	 * @deprecated Use allowDeprecatedTermSelection instead
+	 */
 	allowDeprecatedTerms?: boolean;
-
+	/**
+	 * @deprecated Use allowDisabledTermSelection instead
+	 */
 	allowDisabledTerms?: boolean;
+
+	allowDeprecatedTermSelection?: boolean;
+
+	allowDisabledTermSelection?: boolean;
 
 	/**
 	 * Optional class for the root TaxonomyPicker element
@@ -19,7 +28,15 @@ export interface ITaxonomyPickerProps {
 
 	dialogProps?: Pick<
 		ITaxonomyPickerDialogProps,
-		"className" | "dialogContentProps" | "labels" | "onRenderTreeItem" | "rootNodeLabel" | "showRootNode" | "styles"
+		| "className"
+		| "dialogContentProps"
+		| "labels"
+		| "onRenderTreeItem"
+		| "rootNodeLabel"
+		| "showRootNode"
+		| "styles"
+		| "trimDeprecatedTerms"
+		| "trimUnavailableTerms"
 	>;
 
 	disabled?: boolean;
@@ -45,9 +62,9 @@ export interface ITaxonomyPickerProps {
 
 	theme?: ITheme;
 
-	onRenderOpenDialogButton?: IRenderFunction<ITaxonomyPickerDialogButtonProps>;
-
 	onChange(items: ITermValue[]): void;
+
+	onGetErrorMessage?(selectedItems: ITermValue[]): string | JSX.Element | PromiseLike<string | JSX.Element> | undefined;
 
 	/**
 	 * When specified, allows to override the error message that is being set when creating a new term fails.
@@ -65,7 +82,7 @@ export interface ITaxonomyPickerProps {
 	 */
 	onReceiveTermCreationSuccessMessage?(newValue: string, message: string): string | JSX.Element;
 
-	onGetErrorMessage?(selectedItems: ITermValue[]): string | JSX.Element | PromiseLike<string | JSX.Element> | undefined;
+	onRenderOpenDialogButton?: IRenderFunction<ITaxonomyPickerDialogButtonProps>;
 }
 
 export interface ITaxonomyPickerStyleProps {
@@ -75,9 +92,9 @@ export interface ITaxonomyPickerStyleProps {
 
 export interface ITaxonomyPickerStyles {
 	root?: IStyle;
+	errorMessage?: IStyle;
 	inputWrapper?: IStyle;
 	input?: IStyle;
-	errorMessage?: IStyle;
 	successMessage?: IStyle;
 }
 

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.base.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.base.tsx
@@ -31,22 +31,22 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 	const {
 		labels: labelsProp,
 		allowAddingTerms,
-		allowDisabledTerms,
-		allowDeprecatedTerms,
-		itemLimit,
-		showRootNode,
-		rootNodeLabel,
-		pickerProps,
-		modalProps,
-		dialogContentProps,
 		defaultSelectedItems,
-		onCreateNewTerm,
+		dialogContentProps,
+		itemLimit,
+		modalProps,
 		onConfirm,
+		onCreateNewTerm,
 		onDismiss,
 		onRenderTreeItem,
+		pickerProps,
 		provider,
+		rootNodeLabel,
+		showRootNode,
 		styles,
 		theme,
+		trimDeprecatedTerms,
+		trimUnavailableTerms,
 		...rest
 	} = props;
 	const { className: modalClassName } = modalProps || {};
@@ -88,12 +88,12 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 		(async () => {
 			const filterOptions: Partial<ITermFilterOptions> = {};
 
-			if (allowDeprecatedTerms !== undefined) {
-				filterOptions.trimDeprecated = !allowDeprecatedTerms;
+			if (trimDeprecatedTerms !== undefined) {
+				filterOptions.trimDeprecated = trimDeprecatedTerms;
 			}
 
-			if (allowDisabledTerms !== undefined) {
-				filterOptions.trimUnavailable = !allowDisabledTerms;
+			if (trimUnavailableTerms !== undefined) {
+				filterOptions.trimUnavailable = trimUnavailableTerms;
 			}
 
 			const terms = rfdc()(await provider.getTermTree(filterOptions));
@@ -101,7 +101,7 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 			setTermTreeItems(terms);
 			setExpandedNodes(showRootNode ? [rootNodeKey] : terms && terms.length > 0 ? [terms[0].key] : []);
 		})();
-	}, [provider, showRootNode, rootNodeKey, allowDeprecatedTerms, allowDisabledTerms]);
+	}, [provider, showRootNode, rootNodeKey, trimDeprecatedTerms, trimUnavailableTerms]);
 
 	React.useEffect(() => {
 		if (!termTreeItems) {

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.types.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.types.ts
@@ -5,34 +5,38 @@ import { ITermAdderLabels } from "../TermAdder";
 import { ITaxonomyProvider, ITerm, ITermCreationResult } from "../models";
 
 export interface ITaxonomyPickerDialogLabels {
-	okButton?: string;
-	cancelButton?: string;
 	addButton?: string;
-	replaceButton?: string;
 	addNewTermAction?: string;
+	cancelButton?: string;
+	okButton?: string;
+	replaceButton?: string;
 	termAdderLabels?: ITermAdderLabels;
 }
 
 interface ITaxonomyPickerDialogPropsBase {
 	allowAddingTerms?: boolean;
 
-	allowDisabledTerms?: boolean;
-
-	allowDeprecatedTerms?: boolean;
-
-	provider: ITaxonomyProvider;
-
-	showRootNode?: boolean;
-
-	rootNodeLabel?: string;
-
 	defaultSelectedItems?: ITermValue[];
-
-	pickerProps: ITermPickerProps;
 
 	itemLimit?: number;
 
 	labels?: ITaxonomyPickerDialogLabels;
+
+	pickerProps: ITermPickerProps;
+
+	provider: ITaxonomyProvider;
+
+	rootNodeLabel?: string;
+
+	showRootNode?: boolean;
+
+	trimDeprecatedTerms?: boolean;
+
+	trimUnavailableTerms?: boolean;
+
+	onConfirm?(terms?: ITermValue[]): void;
+
+	onCreateNewTerm?(newValue: string, parentId?: string): PromiseLike<void | ITermCreationResult>;
 
 	/**
 	 * When specified it will override the default rendering of the tree items
@@ -48,10 +52,6 @@ interface ITaxonomyPickerDialogPropsBase {
 	 * The current theme applied to the control
 	 */
 	theme?: ITheme;
-
-	onConfirm?(terms?: ITermValue[]): void;
-
-	onCreateNewTerm?(newValue: string, parentId?: string): PromiseLike<void | ITermCreationResult>;
 }
 
 export type ITaxonomyPickerDialogProps = ITaxonomyPickerDialogPropsBase & IDialogProps;
@@ -64,10 +64,10 @@ export interface ITaxonomyPickerDialogStyleProps {
 
 export interface ITaxonomyPickerDialogStyles {
 	dialog?: IStyle;
-	content?: IStyle;
-	treeContainer?: IStyle;
-	inputsContainer?: IStyle;
-	addButton?: IStyle;
-	picker?: IStyle;
 	actions?: IStyle;
+	addButton?: IStyle;
+	content?: IStyle;
+	inputsContainer?: IStyle;
+	picker?: IStyle;
+	treeContainer?: IStyle;
 }

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/stories/TaxonomyPicker.stories.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/stories/TaxonomyPicker.stories.tsx
@@ -14,8 +14,8 @@ const defaultArgTypes = {
 
 const defaultArgs: Partial<ITaxonomyPickerProps> = {
 	allowAddingTerms: false,
-	allowDeprecatedTerms: false,
-	allowDisabledTerms: false,
+	allowDeprecatedTermSelection: false,
+	allowDisabledTermSelection: false,
 	itemLimit: 3,
 	label: "Demo taxonomy picker",
 	required: false,


### PR DESCRIPTION
## Type of change

- [x] Bugfix
- [ ] Component improvement
- [ ] New component
- [ ] New package
- [ ] Other

## Description

Improve handling disabled terms in term tree (BREAKING!)

### Breaking change

There is now a distinction in `TaxonomyPicker` where allowing disabled/deprecated terms to be selected is considered separately from showing them in the dialog.
Showing/hiding unavailable terms in the `TaxonomyPickerDialog` is now handled through the picker's `dialogProps`: `trimDeprecatedTerms` and `trimUnavailableTerms`.

Example implementation (this is the default behaviour when properties are not passed):
```
<TaxonomyPicker
  ...
  allowDeprecatedTermSelection={false}
  allowDisabledTermSelection={false}
  dialogProps={{
	  ...
	  trimDeprecatedTerms: true,
	  trimUnavailableTerms: false
  }}
/>
``` 