### PR TITLE
fix: Fluent UI Component imports

### DIFF
--- a/change/@dlw-digitalworkplace-dw-react-controls-68ec9bbd-4c3f-415c-967a-f5f7d14c8aea.json
+++ b/change/@dlw-digitalworkplace-dw-react-controls-68ec9bbd-4c3f-415c-967a-f5f7d14c8aea.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: Fluent UI Component imports",
+  "packageName": "@dlw-digitalworkplace/dw-react-controls",
+  "email": "robin.agten@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/dw-react-controls/src/components/AutocompleteSearchBox/AutocompleteSearchBox.types.ts
+++ b/packages/dw-react-controls/src/components/AutocompleteSearchBox/AutocompleteSearchBox.types.ts
@@ -1,20 +1,13 @@
 import { ILinkStyleProps, ILinkStyles } from "@fluentui/react";
-import {
-	ICalloutContentStyleProps,
-	ICalloutContentStyles,
-	ICalloutProps
-} from "@fluentui/react/lib/components/Callout";
-import { ISearchBoxProps, ISearchBoxStyleProps, ISearchBoxStyles } from "@fluentui/react/lib/components/SearchBox";
+import { ICalloutContentStyleProps, ICalloutContentStyles, ICalloutProps } from "@fluentui/react/lib/Callout";
+import { ISearchBoxProps, ISearchBoxStyleProps, ISearchBoxStyles } from "@fluentui/react/lib/SearchBox";
 import { IStyle, ITheme } from "@fluentui/react/lib/Styling";
 import { IStyleFunctionOrObject } from "@fluentui/react/lib/Utilities";
 import {
 	IHighlightedSuggestionStyleProps,
 	IHighlightedSuggestionStyles
 } from "./HighlightedSuggestion/HighlightedSuggestion.types";
-import {
-	IProgressIndicatorStyleProps,
-	IProgressIndicatorStyles
-} from "@fluentui/react/lib/components/ProgressIndicator";
+import { IProgressIndicatorStyleProps, IProgressIndicatorStyles } from "@fluentui/react/lib/ProgressIndicator";
 
 export interface IAutocompleteSearchBoxProps extends ISearchBoxProps {
 	styles?: IStyleFunctionOrObject<IAutocompleteSearchBoxStyleProps, IAutocompleteSearchBoxStyles>;

--- a/packages/dw-react-controls/src/components/AutocompleteSearchBox/AutocompleteSearchbox.base.tsx
+++ b/packages/dw-react-controls/src/components/AutocompleteSearchBox/AutocompleteSearchbox.base.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import { ISearchBoxStyles, SearchBox } from "@fluentui/react/lib/components/SearchBox";
+import { ISearchBoxStyles, SearchBox } from "@fluentui/react/lib/SearchBox";
 import { IAutocompleteSearchBoxProps, IAutocompleteSearchBoxStyleProps, IAutocompleteSearchBoxStyles } from "./AutocompleteSearchBox.types";
 import { classNamesFunction } from "@fluentui/react/lib/Utilities";
-import { IconButton } from "@fluentui/react/lib/components/Button";
+import { IconButton } from "@fluentui/react/lib/Button";
 import { Callout, DirectionalHint, ICalloutContentStyles } from "@fluentui/react/lib/Callout";
-import { IProgressIndicatorStyles, ProgressIndicator } from "@fluentui/react/lib/components/ProgressIndicator";
+import { IProgressIndicatorStyles, ProgressIndicator } from "@fluentui/react/lib/ProgressIndicator";
 import { useDebounceFn } from "@dlw-digitalworkplace/dw-react-utils";
 import { FocusZone, FocusZoneDirection, IFocusZone } from "@fluentui/react/lib/FocusZone";
 import { ILinkStyles, Link } from "@fluentui/react/lib/Link";


### PR DESCRIPTION
## Type of change

- [x] Bugfix
- [ ] Component improvement
- [ ] New component
- [ ] New package
- [ ] Other

## Description
Importing components directly instead of via a `lib/components` path. This causes issues in when using fluentui/react v8 in combination with fluentui/react v9
