### PR TITLE
feat: add inputprops to taxonomypicker

### DIFF
--- a/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/components/DemoTaxonomyPicker.tsx
+++ b/apps/demo-spfx-app/src/webparts/demoTaxonomyPicker/components/DemoTaxonomyPicker.tsx
@@ -63,6 +63,7 @@ export const DemoTaxonomyPicker: React.FC<IDemoTaxonomyPickerProps> = (props) =>
 				allowDeprecatedTermSelection={allowDeprecatedTerms}
 				allowDisabledTermSelection={allowDisabledTerms}
 				disabled={!provider}
+				inputProps={{ placeholder: "Add Terms" }}
 				onChange={setSelectedItems}
 				provider={provider}
 				selectedItems={selectedItems}

--- a/change/@dlw-digitalworkplace-dw-react-controls-d9f4353e-1f6d-44d7-83ad-046a6fa2543a.json
+++ b/change/@dlw-digitalworkplace-dw-react-controls-d9f4353e-1f6d-44d7-83ad-046a6fa2543a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add inputprops to taxonomypicker",
+  "packageName": "@dlw-digitalworkplace/dw-react-controls",
+  "email": "stef.santens@delaware.pro",
+  "dependentChangeType": "patch"
+}

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.base.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.base.tsx
@@ -30,6 +30,7 @@ export const TaxonomyPickerBase: React.FC<ITaxonomyPickerProps> = ({
 	className,
 	disabled,
 	errorMessage: errorMessageProp,
+	inputProps,
 	itemLimit,
 	label,
 	labelProps,
@@ -327,7 +328,8 @@ export const TaxonomyPickerBase: React.FC<ITaxonomyPickerProps> = ({
 					createGenericItem={onCreateGenericItem}
 					disabled={disabled || isCreatingTerm}
 					inputProps={{
-						id: inputId
+						id: inputId,
+						...inputProps
 					}}
 					isInvalid={!!errorMessage ? true : undefined}
 					itemLimit={itemLimit}

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPicker.types.ts
@@ -1,4 +1,4 @@
-import { ILabelProps, IRenderFunction, IStyle, IStyleFunctionOrObject, ITheme } from "@fluentui/react";
+import { IInputProps, ILabelProps, IRenderFunction, IStyle, IStyleFunctionOrObject, ITheme } from "@fluentui/react";
 import { ITermPickerProps, ITermValue } from "../TermPicker";
 import { ITaxonomyPickerDialogProps } from "./TaxonomyPickerDialog";
 import { ITaxonomyProvider } from "./models";
@@ -40,6 +40,8 @@ export interface ITaxonomyPickerProps {
 	>;
 
 	disabled?: boolean;
+
+	inputProps?: IInputProps;
 
 	itemLimit?: number;
 


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [x] Component improvement
- [ ] New component
- [ ] New package
- [ ] Other

## Description

Added inputprops to taxonomypicker.
This is added to access the inputprops when using the component to add a placeholder for example

❤ Thank you for contributing!
