### PR TITLE
fix(TaxPicker): prevent hidden OK button below fold

### DIFF
--- a/change/@dlw-digitalworkplace-dw-react-controls-1c0e0c0a-89ea-494b-baa3-052d23c9cac8.json
+++ b/change/@dlw-digitalworkplace-dw-react-controls-1c0e0c0a-89ea-494b-baa3-052d23c9cac8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(TaxPicker): prevent hidden OK button below fold",
+  "packageName": "@dlw-digitalworkplace/dw-react-controls",
+  "email": "pieter.heemeryck@delaware.pro",
+  "dependentChangeType": "patch"
+}

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.base.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.base.tsx
@@ -345,6 +345,12 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 					itemLimit={itemLimit}
 					selectedItems={selectedItems}
 					onChange={handlePickerChange}
+					styles={{
+						text: {
+							maxHeight: "125px",
+							overflowY: "auto"
+						}
+					}}
 				/>
 			</div>
 

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.base.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.base.tsx
@@ -347,7 +347,7 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 					onChange={handlePickerChange}
 					styles={{
 						text: {
-							maxHeight: "125px",
+							maxHeight: "122px",
 							overflowY: "auto"
 						}
 					}}


### PR DESCRIPTION
## Type of change

- [x] Bugfix

## Description

Too many selections lead to pushing the footer down. User is unable to select the OK button.
