### PR TITLE
fix(TaxonomyPicker): fix visual when focused

### DIFF
--- a/change/@dlw-digitalworkplace-dw-react-controls-f25e0fd5-589e-499e-b051-df0b7f051836.json
+++ b/change/@dlw-digitalworkplace-dw-react-controls-f25e0fd5-589e-499e-b051-df0b7f051836.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(TaxonomyPicker): fix visual when focused",
+  "packageName": "@dlw-digitalworkplace/dw-react-controls",
+  "email": "pieter.heemeryck@delaware.pro",
+  "dependentChangeType": "patch"
+}

--- a/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.base.tsx
+++ b/packages/dw-react-controls/src/components/TaxonomyPicker/TaxonomyPickerDialog/TaxonomyPickerDialog.base.tsx
@@ -348,7 +348,11 @@ export const TaxonomyPickerDialogBase: React.FC<ITaxonomyPickerDialogProps> = (p
 					styles={{
 						text: {
 							maxHeight: "122px",
-							overflowY: "auto"
+							overflowY: "auto",
+							"::after": {
+								inset: "0px",
+								border: "none"
+							}
 						}
 					}}
 				/>


### PR DESCRIPTION
## Type of change

- [x] Bugfix

## Description

 - Fixed the visual when focused. Inset property causes scrollbars to be shown even when still empty.
 - Fix for bug introduced in v1.7.1: due to the fixed height, the "::after" styling showed a wrong border. 
