### PR TITLE
fix: Extra docs in SPFx controls installation

### DIFF
--- a/change/@dlw-digitalworkplace-dw-spfx-controls-fdeeb7c2-ceed-4d90-a0c6-756f1e8c080f.json
+++ b/change/@dlw-digitalworkplace-dw-spfx-controls-fdeeb7c2-ceed-4d90-a0c6-756f1e8c080f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added extra documentation on installation process of dw-spfx-controls",
+  "packageName": "@dlw-digitalworkplace/dw-spfx-controls",
+  "email": "robin.agten@delaware.pro",
+  "dependentChangeType": "patch"
+}

--- a/packages/dw-spfx-controls/stories/Introduction.stories.mdx
+++ b/packages/dw-spfx-controls/stories/Introduction.stories.mdx
@@ -17,6 +17,15 @@ These controls are designed specifically for use within an SPFx context, and (ca
 yarn add @dlw-digitalworkplace/dw-spfx-controls
 ```
 
+> 💡 Make sure you provide the path to your localization files in the `config.json` file.
+
+```json
+"localizedResources": {
+	...
+	"DWControlStrings": "./node_modules/@dlw-digitalworkplace/dw-spfx-controls/lib/loc/{locale}.js"
+}
+```
+
 ## Controls
 
 The package contains the following top-level controls:


### PR DESCRIPTION
## fix: Extra docs in SPFx controls installation
It is needed to provide the path to the `DWControlStrings` when using the `dw-spfx-controls` package. I added this to the installation page

- [ ] Bugfix
- [ ] Component improvement
- [ ] New component
- [ ] New package
- [X] Other: Extra docs